### PR TITLE
fix: replace execSync+curl with fetch+FormData in uploadMedia (#1)

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -739,16 +739,20 @@ async function uploadMedia(
   filePath: string,
   mimeType: string,
 ): Promise<string> {
-  const { execSync } = await import('child_process')
-  const result = execSync(
-    `curl -s -X POST "${GRAPH_API}/${PHONE_NUMBER_ID}/media" ` +
-      `-H "Authorization: Bearer ${ACCESS_TOKEN}" ` +
-      `-F "messaging_product=whatsapp" ` +
-      `-F "file=@${filePath};type=${mimeType}" ` +
-      `-F "type=${mimeType}"`,
-    { encoding: 'utf-8', timeout: 30000 },
-  )
-  const data = JSON.parse(result)
+  const file = Bun.file(filePath)
+  const blob = new Blob([await file.arrayBuffer()], { type: mimeType })
+  const form = new FormData()
+  form.append('messaging_product', 'whatsapp')
+  form.append('type', mimeType)
+  form.append('file', blob, basename(filePath))
+
+  const res = await fetch(`${GRAPH_API}/${PHONE_NUMBER_ID}/media`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${ACCESS_TOKEN}` },
+    body: form,
+    signal: AbortSignal.timeout(30000),
+  })
+  const data = (await res.json()) as { id?: string; error?: unknown }
   if (!data.id) throw new Error(`Upload failed: ${JSON.stringify(data)}`)
   return data.id
 }


### PR DESCRIPTION
## Summary
- Replace \`execSync('curl ...')\` in \`uploadMedia\` (server.ts:661-677) with native \`fetch\` + \`FormData\` + \`Bun.file\`
- Drop the \`await import('child_process')\`
- Move \`ACCESS_TOKEN\` from shell argv to the \`Authorization\` HTTP header

Closes #1.

## Why this is load-bearing

The previous code:

\`\`\`ts
const { execSync } = await import('child_process')
const result = execSync(
  \`curl -s -X POST \"\${GRAPH_API}/\${PHONE_NUMBER_ID}/media\" \` +
    \`-H \"Authorization: Bearer \${ACCESS_TOKEN}\" \` +
    \`-F \"messaging_product=whatsapp\" \` +
    \`-F \"file=@\${filePath};type=\${mimeType}\" \` +
    \`-F \"type=\${mimeType}\"\`,
  { encoding: 'utf-8', timeout: 30000 },
)
\`\`\`

Two problems:

1. **Command injection** — \`filePath\` and \`mimeType\` were concatenated into a shell command. A path containing shell metachars (\`;\`, \`\$(...)\`, backticks, \`|\`, \`&\`) reached the shell unescaped. Inbound WhatsApp media filenames are an attacker-controlled vector (closing #2 separately handles the upstream sanitization side).
2. **Token leakage** — \`ACCESS_TOKEN\` rode in \`argv\`. Any process on the host running \`ps -ef\` (or auditd, or a shared-host neighbor) saw it.

## New implementation

\`\`\`ts
async function uploadMedia(
  filePath: string,
  mimeType: string,
): Promise<string> {
  const file = Bun.file(filePath)
  const blob = new Blob([await file.arrayBuffer()], { type: mimeType })
  const form = new FormData()
  form.append('messaging_product', 'whatsapp')
  form.append('type', mimeType)
  form.append('file', blob, basename(filePath))

  const res = await fetch(\`\${GRAPH_API}/\${PHONE_NUMBER_ID}/media\`, {
    method: 'POST',
    headers: { Authorization: \`Bearer \${ACCESS_TOKEN}\` },
    body: form,
    signal: AbortSignal.timeout(30000),
  })
  const data = (await res.json()) as { id?: string; error?: unknown }
  if (!data.id) throw new Error(\`Upload failed: \${JSON.stringify(data)}\`)
  return data.id
}
\`\`\`

- No \`child_process\` anywhere in the file (verified: \`grep child_process server.ts\` returns 0 lines).
- Token only in the HTTP header.
- Filename for the multipart \"file\" part comes from \`basename(filePath)\` — Graph API needs a name on the file part; we send the basename only (no path).
- Timeout preserved via \`AbortSignal.timeout(30000)\` (matches old 30s).
- Return contract unchanged (\`{ id }\` or throws).

## Static gates

- **Typecheck**: \`bunx tsc --noEmit -p tsconfig.json\` exit 0
- **No \`child_process\`**: \`grep -n 'child_process\\|execSync' server.ts\` → 0 matches
- **No new \`any\`**: response narrowed to \`{ id?: string; error?: unknown }\`
- **Single-path**: full replacement, no compat wrapper, no flag

## Manual probe (to be run by Reinaldo at review time)

Per shape §16 PR1 evidence_plan + Reinaldo's confirmation in #16, the live probe runs against +55 61 98559-8585 (RIA's WhatsApp Business). Two upload flows must succeed:

1. **1-byte text fixture** as document — proves the basic upload path
2. **Real \`.ogg\` voice note** — proves the audio/voice flow used by the \`reply\` tool's voice-note branch

Expected: each upload returns a Graph media id (visible in plugin stderr log: \`saved media: ...\`). \`ps -ef\` during the upload should show no \`curl\` invocation.

## Diff scope

| File | Change | LOC |
|---|---|---|
| \`server.ts\` | \`uploadMedia\` rewrite + \`basename\` import | +15 / −11 |

Total ~15 net LOC, no other surface touched.

## Part of v0.1.6 release plan

This is PR 2 of 6. Sequence: PR5 (#3, merged) → **PR1 (this) → PR2 (#2) → PR3 (#4+#5) → PR4 (#15) → PR6 (#6)**. Tracking: #16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)