### PR TITLE
fix: sanitize WhatsApp document filename in downloadAndSaveMedia (#2)

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -12,9 +12,9 @@ import {
   CallToolRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js'
 import { Database } from 'bun:sqlite'
-import { readFileSync, writeFileSync, readdirSync, mkdirSync, rmSync, existsSync } from 'fs'
+import { readFileSync, writeFileSync, readdirSync, mkdirSync, rmSync, existsSync, realpathSync } from 'fs'
 import { homedir } from 'os'
-import { join } from 'path'
+import { basename, join, resolve, sep } from 'path'
 import { z } from 'zod'
 
 // ── Config ──────────────────────────────────────────────────────────────────
@@ -192,6 +192,10 @@ function chatIdFromPhone(phone: string): string {
 mkdirSync(STATE_DIR, { recursive: true, mode: 0o700 })
 mkdirSync(MEDIA_DIR, { recursive: true, mode: 0o700 })
 mkdirSync(join(STATE_DIR, 'approved'), { recursive: true, mode: 0o700 })
+
+// Resolve once at startup (after MEDIA_DIR is guaranteed to exist) so path-
+// traversal checks compare against a canonical path, not a symlink.
+const REAL_MEDIA_DIR = realpathSync(MEDIA_DIR)
 
 const db = new Database(DB_PATH)
 db.exec('PRAGMA journal_mode=WAL')
@@ -529,6 +533,34 @@ const MIME_TO_EXT: Record<string, string> = {
   'application/msword': 'doc',
 }
 
+/**
+ * Build a safe absolute write path inside MEDIA_DIR from an
+ * attacker-controlled filename (WhatsApp document captions reach
+ * here). Strips directory components, rejects dot-only and
+ * null-byte names, applies the mime-derived extension if any, and
+ * verifies the final resolved path stays under MEDIA_DIR. Throws
+ * if the resolved path escapes (defense-in-depth — basename should
+ * already prevent this).
+ */
+function safeMediaPath(
+  filename: string,
+  mediaId: string,
+  ext: string | undefined,
+): string {
+  let safe = basename(filename)
+  if (!safe || safe === '.' || safe === '..' || safe.includes('\0')) {
+    safe = ext ? `${mediaId}.${ext}` : mediaId
+  }
+  if (ext && !safe.endsWith(`.${ext}`)) {
+    safe = safe.replace(/\.[^.]+$/, '') + `.${ext}`
+  }
+  const resolved = resolve(REAL_MEDIA_DIR, safe)
+  if (!resolved.startsWith(REAL_MEDIA_DIR + sep)) {
+    throw new Error(`refusing to save outside MEDIA_DIR: ${filename}`)
+  }
+  return resolved
+}
+
 async function downloadAndSaveMedia(
   mediaId: string,
   fallbackFilename?: string,
@@ -547,16 +579,13 @@ async function downloadAndSaveMedia(
   if (!mediaRes.ok) throw new Error(`Download failed: ${mediaRes.status}`)
   const buffer = Buffer.from(await mediaRes.arrayBuffer())
 
-  // Step 3: Determine filename
-  let filename = fallbackFilename || `${mediaId}`
+  // Step 3: Sanitize filename and compute safe write path inside MEDIA_DIR
+  const fallback = fallbackFilename || `${mediaId}`
   const mimeType = urlData.mime_type || ''
   const ext = MIME_TO_EXT[mimeType]
-  if (ext && !filename.endsWith(`.${ext}`)) {
-    filename = filename.replace(/\.[^.]+$/, '') + `.${ext}`
-  }
+  const filePath = safeMediaPath(fallback, mediaId, ext)
 
-  // Step 4: Save to media directory
-  const filePath = join(MEDIA_DIR, filename)
+  // Step 4: Save
   writeFileSync(filePath, buffer)
   log(`saved media: ${filePath} (${buffer.length} bytes)`)
   return filePath


### PR DESCRIPTION
## Summary
- Strip directory components from inbound WhatsApp document filenames before writing
- Reject empty / dot-only / null-byte names → fallback to \`\${mediaId}.\${ext}\`
- Verify resolved path stays inside \`realpathSync(MEDIA_DIR)\` — throw otherwise (defense-in-depth)

Closes #2.

## Why this is load-bearing

\`downloadAndSaveMedia\` (server.ts:551) used to do:

\`\`\`ts
let filename = fallbackFilename || \`\${mediaId}\`
// ... mime-extension fix-up ...
const filePath = join(MEDIA_DIR, filename)
writeFileSync(filePath, buffer)
\`\`\`

\`fallbackFilename\` flows from the inbound webhook handler (server.ts:1353-1356) where it's extracted from \`msg.body\` via the regex \`/\\[Document: (.+?)\\]/\`. The match group reaches \`writeFileSync\` untouched.

A WhatsApp message with body \`[Document: ../../../.ssh/authorized_keys]\` writes \`buffer\` to the user's SSH directory. Demonstrated chains: ssh authorized_keys plant, \`.zshrc\` backdoor, \`~/.claude/settings.json\` tamper. Every inbound document that reaches the plugin is a planting opportunity until this lands.

## New implementation

A \`safeMediaPath\` helper centralizes the boundary:

\`\`\`ts
function safeMediaPath(filename: string, mediaId: string, ext: string | undefined): string {
  let safe = basename(filename)
  if (!safe || safe === '.' || safe === '..' || safe.includes('\\0')) {
    safe = ext ? \`\${mediaId}.\${ext}\` : mediaId
  }
  if (ext && !safe.endsWith(\`.\${ext}\`)) {
    safe = safe.replace(/\\.[^.]+\$/, '') + \`.\${ext}\`
  }
  const resolved = resolve(REAL_MEDIA_DIR, safe)
  if (!resolved.startsWith(REAL_MEDIA_DIR + sep)) {
    throw new Error(\`refusing to save outside MEDIA_DIR: \${filename}\`)
  }
  return resolved
}
\`\`\`

Two layers of defense:
1. **\`basename\` strips directory traversal** (\`../../etc/passwd\` → \`passwd\`). This handles the entire common case.
2. **Resolved-path startsWith check** is defense-in-depth in case some basename edge case (Windows-style separators, symlink quirks, future Bun behavior) sneaks past — final write target must canonicalize inside \`MEDIA_DIR\`.

\`REAL_MEDIA_DIR\` is computed once at module load via \`realpathSync(MEDIA_DIR)\`, placed **after** the existing \`mkdirSync(MEDIA_DIR, { recursive: true })\` at server.ts:193 — placement order matters because \`realpathSync\` throws \`ENOENT\` on a non-existent path.

## Sanitization fixture (12/12 pass)

\`\`\`
PASS  in=\"report.pdf\"           ext=pdf   → /tmp/wa-media/report.pdf
PASS  in=\"../../etc/passwd\"     ext=_     → /tmp/wa-media/passwd
PASS  in=\"../../etc/passwd\"     ext=pdf   → /tmp/wa-media/passwd.pdf
PASS  in=\"/etc/passwd\"          ext=pdf   → /tmp/wa-media/passwd.pdf
PASS  in=\"..\"                   ext=pdf   → /tmp/wa-media/M1.pdf
PASS  in=\".\"                    ext=pdf   → /tmp/wa-media/M1.pdf
PASS  in=\"\"                     ext=pdf   → /tmp/wa-media/M1.pdf
PASS  in=\"foo\\u0000bar.pdf\"     ext=pdf   → /tmp/wa-media/M1.pdf
PASS  in=\"photo.jpg\"            ext=jpg   → /tmp/wa-media/photo.jpg
PASS  in=\"photo.jpeg\"           ext=jpg   → /tmp/wa-media/photo.jpg
PASS  in=\"photo\"                ext=jpg   → /tmp/wa-media/photo.jpg
PASS  in=\"report.pdf\"           ext=_     → /tmp/wa-media/report.pdf
\`\`\`

Notable cases:
- \`../../etc/passwd\` (with or without ext) collapses to \`passwd\` (or \`passwd.pdf\`)
- \`.\` and \`..\` and \`\"\"\` fall back to \`M1.pdf\` (mediaId + ext)
- Null byte → fallback (defense against truncation tricks)
- Mime-extension correction still works for legit filenames missing the extension

## Static gates

- **Typecheck**: \`bunx tsc --noEmit -p tsconfig.json\` exit 0
- **No new \`any\`**: \`urlData\` cast at L540 is pre-existing (out of scope per #13 dead-code cleanup)
- **Single-path**: full replacement, no flag, no compat wrapper

## Diff scope

| File | Change | LOC |
|---|---|---|
| \`server.ts\` | imports (+ \`basename\`, \`resolve\`, \`sep\`, \`realpathSync\`) | +2 / −2 |
| \`server.ts\` | \`REAL_MEDIA_DIR\` after \`mkdirSync(MEDIA_DIR)\` | +4 / −0 |
| \`server.ts\` | \`safeMediaPath\` helper + downloadAndSaveMedia rewrite | +32 / −7 |

Total ~30 net LOC.

## Why no upstream sanitization at L1353-1356

Round-1 shape mentioned applying basename at the regex extraction site too. That's redundant — \`safeMediaPath\` is the boundary inside \`downloadAndSaveMedia\`, and any caller (current or future) gets the same protection. Single sanitization point is cleaner.

## Manual probe (recommended at review)

Send a WhatsApp document to the WABA with the filename \`../../.ssh/authorized_keys\` (or any traversal payload). Confirm:
1. The file lands inside \`~/.claude/channels/whatsapp/media/\` (not in \`~/.ssh/\`)
2. Plugin stderr shows \`saved media: /...whatsapp/media/authorized_keys (N bytes)\`
3. \`~/.ssh/authorized_keys\` is unchanged

## Part of v0.1.6 release plan

This is PR 3 of 6. Sequence: PR5 (#3, merged) → PR1 (#1, in review #19) → **PR2 (this) → PR3 (#4+#5) → PR4 (#15) → PR6 (#6)**. Tracking: #16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)