### PR TITLE
fix: gate reply/react outbound and reply.files paths (#4 #5)

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -237,6 +237,7 @@ mkdirSync(join(STATE_DIR, 'approved'), { recursive: true, mode: 0o700 })
 // Resolve once at startup (after MEDIA_DIR is guaranteed to exist) so path-
 // traversal checks compare against a canonical path, not a symlink.
 const REAL_MEDIA_DIR = realpathSync(MEDIA_DIR)
+const REAL_STATE_DIR = realpathSync(STATE_DIR)
 
 const db = new Database(DB_PATH)
 db.exec('PRAGMA journal_mode=WAL')
@@ -600,6 +601,55 @@ function safeMediaPath(
     throw new Error(`refusing to save outside MEDIA_DIR: ${filename}`)
   }
   return resolved
+}
+
+/**
+ * Reject outbound destinations not in our trust set. WhatsApp's reply.chat_id
+ * is a free-form parameter — without this gate, a prompt-injected Claude can
+ * send to any phone it picks. Three accepted sources of trust:
+ * - the WABA's own number (self)
+ * - operator-curated allowlist (access.allowFrom)
+ * - phones that recently messaged us within the lastInboundByChat window
+ *   (600s; aligned with the existing eviction at the inbound handler)
+ *
+ * No mode asymmetry between reply and react — same gate for both.
+ */
+function assertSendablePhone(phone: string): void {
+  const target = normalizePhone(phone)
+  if (target && SELF_PHONE && target === SELF_PHONE) return
+  const access = loadAccess()
+  if (access.allowFrom.some((a) => phonesMatch(a, phone))) return
+  const cid = chatIdFromPhone(phone)
+  const rec = lastInboundByChat.get(cid)
+  if (rec) {
+    const now = Math.floor(Date.now() / 1000)
+    if ((now - rec.ts) <= 600) return
+  }
+  throw new Error(`not in outbound allowlist: ${phone}`)
+}
+
+/**
+ * Reject sending the server's own state as a file attachment. Mirrors the
+ * canonical pattern from anthropics/claude-plugins-official telegram
+ * (server.ts:135-145) and imessage (server.ts:225-239). Claude can already
+ * Read+paste arbitrary file contents, so this isn't a generic exfil gate —
+ * it only protects channel state (access.json, lockfile, db, etc.) which
+ * Claude has no reason to ever forward. STATE_DIR/media is carved out
+ * because re-forwarding inbound media is a legitimate flow.
+ */
+function assertSendable(f: string): void {
+  let real: string
+  try {
+    real = realpathSync(f)
+  } catch {
+    return // statSync downstream will surface a real error
+  }
+  if (
+    real.startsWith(REAL_STATE_DIR + sep) &&
+    !real.startsWith(REAL_MEDIA_DIR + sep)
+  ) {
+    throw new Error(`refusing to send channel state: ${f}`)
+  }
 }
 
 async function downloadAndSaveMedia(
@@ -1102,16 +1152,7 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
         const files = (args.files as string[] | undefined) ?? []
         const phone = phoneFromChatId(chatId)
 
-        // Check access
-        const access = loadAccess()
-        const allowed =
-          normalizePhone(phone) === SELF_PHONE ||
-          access.allowFrom.some(
-            (a) => normalizePhone(a) === normalizePhone(phone),
-          )
-        if (!allowed && access.dmPolicy !== 'disabled') {
-          // Allow reply to anyone who messaged us (they're in the conversation)
-        }
+        assertSendablePhone(phone)
 
         // Send text chunks
         const chunks = chunkText(text)
@@ -1151,6 +1192,7 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
           mp4: 'video/mp4',
         }
         for (const filePath of files) {
+          assertSendable(filePath)
           const ext = filePath.split('.').pop()?.toLowerCase() || ''
           const mime = mimeMap[ext] || 'application/octet-stream'
           const mediaId = await uploadMedia(filePath, mime)
@@ -1200,6 +1242,7 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
         const messageId = args.message_id as string
         const emoji = args.emoji as string
         const phone = phoneFromChatId(chatId)
+        assertSendablePhone(phone)
         const result = await sendReaction(phone, messageId, emoji)
         if (!result.success) {
           return {


### PR DESCRIPTION
## Summary

Two outbound gates at the tool-handler boundary:

- **\`assertSendablePhone(phone)\`** (RIA-original) — used by both \`reply\` and \`react\`; blocks destinations not in \`{SELF_PHONE, access.allowFrom, recent-inbound ≤600s}\`.
- **\`assertSendable(f)\`** (canonical-aligned) — used inside \`reply.files\` loop; blocks paths under \`STATE_DIR\` egressing to WhatsApp, with \`MEDIA_DIR\` carve-out.

Closes #4. Closes #5.

## Stacked on PR #20

This PR depends on **PR #20 (#2 filename traversal)** for \`REAL_MEDIA_DIR\` + \`realpathSync\` import. Marked **draft** until PR #20 lands. Branched from \`fix/2-filename-traversal\` so the diff visible here is just the gate work; once PR #20 merges to \`main\`, this rebases cleanly.

After PR #20 merges → I rebase this onto \`main\` and remove the draft flag.

## Why each gate is load-bearing

### #4 — phone gate

The current \`reply\` handler has a **dead \`if\` block** (server.ts:1062-1070):

\`\`\`ts
const allowed = normalizePhone(phone) === SELF_PHONE || access.allowFrom.some(...)
if (!allowed && access.dmPolicy !== 'disabled') {
  // Allow reply to anyone who messaged us (they're in the conversation)
}
\`\`\`

The \`if\` body is empty — no \`return\`, no \`throw\`, just a comment documenting intent that was never enforced. \`react\` has no check at all. Both tools accept a free-form \`chat_id\` parameter. A prompt-injected Claude can call \`reply({ chat_id: \"any;-;+5511999999999\", text: \"...\" })\` and it goes through.

**No canonical analog**: I previously cross-referenced \`tg.ts:135-145\` for this on issue #4 — that comment was wrong. \`tg.ts:135-145\` is the file-path validator (which becomes \`assertSendable\` in #5), not a phone gate. Telegram and iMessage don't have this surface because their addressing is contextual, not free-form.

**Implementation** (RIA-original):

\`\`\`ts
function assertSendablePhone(phone: string): void {
  const target = normalizePhone(phone)
  if (target && SELF_PHONE && target === SELF_PHONE) return
  const access = loadAccess()
  if (access.allowFrom.some((a) => phonesMatch(a, phone))) return
  const cid = chatIdFromPhone(phone)
  const rec = lastInboundByChat.get(cid)
  if (rec) {
    const now = Math.floor(Date.now() / 1000)
    if ((now - rec.ts) <= 600) return
  }
  throw new Error(\`not in outbound allowlist: \${phone}\`)
}
\`\`\`

Three accepted sources of trust:
1. **SELF_PHONE** — the WABA's own number.
2. **\`access.allowFrom\`** — operator-curated allowlist; uses \`phonesMatch\` (same tolerant comparison the inbound gate uses for BR DDD9 quirks).
3. **Recent inbound** — anyone who messaged us within \`lastInboundByChat\` 600s window. The 600s aligns with the existing eviction at server.ts:1437-1440 — entries that survived the eviction are still \"in conversation\".

No mode asymmetry between \`reply\` and \`react\`. The earlier shape proposed an asymmetric \`mode: 'reply'|'react'\` discriminator; round-1 TL audit dropped it as design drift without justification. Same gate for both.

### #5 — file gate (canonical pattern)

\`\`\`ts
function assertSendable(f: string): void {
  let real: string
  try { real = realpathSync(f) } catch { return }
  if (real.startsWith(REAL_STATE_DIR + sep) && !real.startsWith(REAL_MEDIA_DIR + sep)) {
    throw new Error(\`refusing to send channel state: \${f}\`)
  }
}
\`\`\`

Adopts the canonical pattern from \`anthropics/claude-plugins-official\`:
- **Telegram** ([\`server.ts:131-145\`](https://github.com/anthropics/claude-plugins-official/blob/0742692/external_plugins/telegram/server.ts#L131-L145)) — same shape with an \`inbox\` carve-out.
- **iMessage** ([\`server.ts:225-239\`](https://github.com/anthropics/claude-plugins-official/blob/0742692/external_plugins/imessage/server.ts#L225-L239)) — same shape, no carve-out (iMessage attachments live outside STATE_DIR).

Threat model matches canonical: **Claude can already Read+paste arbitrary file contents**, so blocking user paths gains nothing. What we close is **channel state egress** — \`access.json\`, \`plugin.pid\`, \`messages.db\`, lockfile, etc. being shipped as documents. \`STATE_DIR/media\` is carved out because re-forwarding inbound media (user sends image → Claude forwards to another contact) is a legitimate flow.

**Non-existent path / symlink error → silent return** (matches canonical \`try { ... } catch { return }\` shape). The actual upload's \`statSync\`/\`Bun.file\` will surface a real error.

## Probe (7/7 pass)

\`\`\`
PASS  /tmp/wa-probe/outside.txt                          → OK     (arbitrary user path)
PASS  /tmp/wa-probe/state/access.json                    → BLOCK  (state file)
PASS  /tmp/wa-probe/state/plugin.pid                     → BLOCK  (state lockfile)
PASS  /tmp/wa-probe/state/media/foo.pdf                  → OK     (state/media carve-out)
PASS  /Users/luoarch/.ssh/id_ed25519                     → OK     (canonical: user paths allowed)
PASS  /tmp/wa-probe/escape-link → state/access.json      → BLOCK  (symlink → state caught via realpath)
PASS  /tmp/nonexistent-xyz                               → OK     (silent return on stat error)
\`\`\`

## Static gates

- **Typecheck**: \`bunx tsc --noEmit -p tsconfig.json\` exit 0
- **Single-path**: dead \`if\` block at L1068-1070 removed (replaced by \`assertSendablePhone\`); no compat shim
- **No new \`any\`**: helpers fully typed
- **Error handling**: thrown errors bubble to the existing outer \`try/catch\` at server.ts:1051/1240 which converts to \`{isError: true, content: [{text: \"reply failed: \${msg}\"}]}\` — the shape's done-criteria contract.

## Diff scope

| Block | Change | LOC |
|---|---|---|
| Imports | (no change — \`realpathSync\`, \`sep\` already from PR #20) | 0 |
| \`REAL_STATE_DIR\` const | new (next to PR #20's \`REAL_MEDIA_DIR\`) | +1 |
| \`assertSendablePhone\` helper | new | +20 |
| \`assertSendable\` (file) helper | new | +18 |
| \`reply\` handler — dead if removed, gate added, file gate added | +2 / −13 |
| \`react\` handler — gate added | +1 |

Total: +53 / −10 = ~43 net LOC.

## Manual probe at review (recommended)

1. **Phone gate, blocked path**: ensure \`access.allowFrom\` does not include +5511999999999 (an arbitrary number); ask Claude to call \`reply({chat_id: \"any;-;+5511999999999\", text: \"hi\"})\`. Expected: \`isError: true\` with text \"reply failed: not in outbound allowlist: 5511999999999\".
2. **Phone gate, allowed via recent-inbound**: send a WhatsApp message to the WABA from a non-allowlisted number; within 10 minutes, ask Claude to \`reply\` to that chat. Expected: succeeds.
3. **File gate, blocked**: ask Claude \`reply({..., files: [\"\$HOME/.claude/channels/whatsapp/access.json\"]})\`. Expected: \`isError: true\` with text \"reply failed: refusing to send channel state: ...\".
4. **File gate, carve-out**: have Claude forward an inbound image (path under \`MEDIA_DIR\`). Expected: succeeds.

## Part of v0.1.6 release plan

This is PR 4 of 6. Sequence: PR5 (#3 ✓ merged) → PR1 (#1, #19) → PR2 (#2, #20) → **PR3 (this) → PR4 (#15) → PR6 (#6)**. Tracking: #16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)