### PR TITLE
fix: scrub permission relay body and sanitize secrets (#15)

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -187,6 +187,47 @@ function chatIdFromPhone(phone: string): string {
   return `any;-;+${digits}`
 }
 
+/**
+ * Mask common secret/PII patterns before sending text to WhatsApp.
+ * Defense-in-depth for the permission relay body — primary protection
+ * is dropping `input_preview` from the rendered body, this catches
+ * residual secrets that may leak via the `description` field that
+ * Claude generates.
+ *
+ * Order: specific token shapes first (Stripe, GitHub, AWS, etc.),
+ * then env-var assignments, then high-entropy fallback. The order
+ * matters: high-entropy would otherwise eat structured tokens.
+ *
+ * Fail-closed: if a regex throws on adversarial input (catastrophic
+ * backtrack), the error bubbles and the relay fails. Failing closed
+ * is safer than sending unsanitized — Claude's permission_request
+ * times out per its own logic and the operator sees nothing leak.
+ */
+const SECRET_PATTERNS: Array<[RegExp, string | ((m: string) => string)]> = [
+  [/sk_live_[A-Za-z0-9_]+/g, '***'],
+  [/sk_test_[A-Za-z0-9_]+/g, '***'],
+  [/pk_(live|test)_[A-Za-z0-9_]+/g, '***'],
+  [/xox[baprs]-[A-Za-z0-9-]+/g, '***'],
+  [/(ghp_|gho_|github_pat_)[A-Za-z0-9_]+/g, '***'],
+  [/AKIA[0-9A-Z]{16}/g, '***'],
+  [/Bearer\s+[A-Za-z0-9._-]+/gi, 'Bearer ***'],
+  [/sk-(ant-)?[A-Za-z0-9_-]{20,}/g, '***'],
+  [/\b\d{3}\.\d{3}\.\d{3}-\d{2}\b/g, '***'],
+  [/\b\d{2}\.\d{3}\.\d{3}\/\d{4}-\d{2}\b/g, '***'],
+  [/\b[A-Z][A-Z0-9_]*=("[^"]{8,}"|'[^']{8,}'|[^\s'"`;&|]{8,})/g, (m: string) => m.split('=')[0] + '=***'],
+  [/\b[A-Za-z0-9+/=_-]{32,}\b/g, '***'],
+]
+
+function sanitizeSecrets(text: string): string {
+  let out = text
+  for (const [re, replacer] of SECRET_PATTERNS) {
+    out = typeof replacer === 'string'
+      ? out.replace(re, replacer)
+      : out.replace(re, replacer)
+  }
+  return out
+}
+
 // ── SQLite Database ─────────────────────────────────────────────────────────
 
 mkdirSync(STATE_DIR, { recursive: true, mode: 0o700 })
@@ -918,21 +959,24 @@ mcp.setNotificationHandler(
       contextLine = `⚙️ _Internal work_\n\n`
     }
 
-    // input_preview is unbearably long for Write/Edit; show only for Bash
-    // where the command itself is the dangerous part.
-    const preview = tool_name === 'Bash' ? `\n\n\`${input_preview.slice(0, 300)}\`` : ''
-    // WhatsApp interactive body limit is 1024 chars — keep it tight.
+    // Body must not leak input_preview or the derived pattern: input_preview
+    // carries the raw tool_input (commands, env-var values, secrets); pattern
+    // tokenizes Bash by whitespace and captures `STRIPE_KEY="sk_live_..."` as
+    // the literal first token. We render `description` (Claude's prose) only,
+    // and sanitizeSecrets is defense-in-depth in case `description` itself
+    // names a secret. WhatsApp interactive body limit is 1024 chars.
     const body =
       `🔐 *Permission required*\n\n` +
       contextLine +
       `🛠  *${tool_name}*\n` +
-      `📝 ${description}${preview}\n\n` +
-      `🔁 *Always* = auto-approve ${pattern} for this session\n` +
+      `📝 ${description}\n\n` +
+      `🔁 *Always* = auto-approve este tipo de solicitação\n` +
       `_ID: ${request_id}_`
     const trimmedBody = body.length > 1020 ? body.slice(0, 1017) + '...' : body
+    const safeBody = sanitizeSecrets(trimmedBody)
 
-    // 3 buttons: allow once / allow always (pattern) / deny
-    const btnResult = await sendInteractiveButtons(PERMISSION_TARGET, trimmedBody, [
+    // 3 buttons: allow once / allow always / deny
+    const btnResult = await sendInteractiveButtons(PERMISSION_TARGET, safeBody, [
       { id: `perm_allow_${request_id}`, title: '✅ Allow' },
       { id: `perm_always_${request_id}`, title: '🔁 Always' },
       { id: `perm_deny_${request_id}`, title: '❌ Deny' },
@@ -944,7 +988,7 @@ mcp.setNotificationHandler(
       `whatsapp channel: buttons failed (${btnResult.error}), falling back to text\n`,
     )
     const text =
-      `${trimmedBody}\n\n` +
+      `${safeBody}\n\n` +
       `Reply "yes ${request_id}" to allow or "no ${request_id}" to deny.`
     const txtResult = await sendText(PERMISSION_TARGET, text)
     if (!txtResult.success) {
@@ -1300,13 +1344,13 @@ async function processWebhookPayload(payload: unknown): Promise<void> {
           if (permAction && permRequestId) {
             const behavior = permAction === 'deny' ? 'deny' : 'allow'
 
-            // On "always": save the pattern for the session
-            let ackSuffix = ''
+            // On "always": save the pattern for the session. The pattern
+            // string never crosses the WhatsApp surface — it only lives in
+            // the in-memory Set used by the auto-allow check at L893.
             if (permAction === 'always') {
               const pending = pendingPermissions.get(permRequestId)
               if (pending) {
                 sessionAllowPatterns.add(pending.pattern)
-                ackSuffix = ` (${pending.pattern})`
                 log(`session-allow pattern added: ${pending.pattern}`)
               }
             }
@@ -1327,7 +1371,7 @@ async function processWebhookPayload(payload: unknown): Promise<void> {
                   : '❌'
             void sendText(
               PERMISSION_TARGET,
-              `${emoji} ${permRequestId}${ackSuffix}`,
+              `${emoji} ${permRequestId}`,
             )
             // Mark this message as stored so we don't reprocess it
             stmtInsertMsg.run(


### PR DESCRIPTION
## Summary
- Drop \`input_preview\` and the permissionPattern literal from the WhatsApp permission body
- Render Claude's MCP \`description\` field directly + secret sanitizer pass before send
- Drop the parenthesized pattern suffix from the \"Always\" ack
- Keep the 3 existing buttons (Allow / Always / Cancelar) — no UX change

Closes #15. Implements Reinaldo's design pivot from PR #16 review (2026-04-29). Sub-shape locked at \`docs/shaping/v0.1.6-security-hotfix/pr4/shaping.md\` (PR #16).

## Why this is load-bearing

The previous handler (server.ts:921-931 on \`main\`) emitted to WhatsApp:

\`\`\`ts
const preview = tool_name === 'Bash' ? \`\\n\\n\\\`\${input_preview.slice(0, 300)}\\\`\` : ''
const body =
  \`🔐 *Permission required*\\n\\n\` +
  contextLine +
  \`🛠  *\${tool_name}*\\n\` +
  \`📝 \${description}\${preview}\\n\\n\` +
  \`🔁 *Always* = auto-approve \${pattern} for this session\\n\` +
  \`_ID: \${request_id}_\`
\`\`\`

Two leaks:

1. **input_preview slice** — Bash carve-out shipped 300 chars of raw \`tool_input\` JSON. \`STRIPE_KEY=\"sk_live_...\" curl ...\` arrived in the user's WhatsApp inbox.
2. **pattern literal** — \`permissionPattern\` (server.ts:809-830) tokenizes Bash by \`/^\\s*([^\\s|;&]+)/\`. An env-var assignment like \`STRIPE_KEY=\"sk_live_xyz\"\` becomes the entire first token. The literal pattern \`Bash:STRIPE_KEY=\"sk_live_xyz\"\` rendered into the \"Always\" line.

Both leaks closed.

## Implementation

### Body construction (server.ts:962-979 in this PR)

\`\`\`ts
const body =
  \`🔐 *Permission required*\\n\\n\` +
  contextLine +
  \`🛠  *\${tool_name}*\\n\` +
  \`📝 \${description}\\n\\n\` +
  \`🔁 *Always* = auto-approve este tipo de solicitação\\n\` +
  \`_ID: \${request_id}_\`
const trimmedBody = body.length > 1020 ? body.slice(0, 1017) + '...' : body
const safeBody = sanitizeSecrets(trimmedBody)
\`\`\`

- No \`input_preview\` reference — variable removed from the closure entirely for body purposes.
- No \`pattern\` interpolation — \"Always\" line is a static phrase.
- \`description\` (Claude's prose, generated per the MCP permission protocol) renders unchanged.
- \`sanitizeSecrets\` runs once on the trimmed body, before \`sendInteractiveButtons\` and before the text-fallback construction.

### Sanitizer (server.ts:189-228 in this PR)

12-pattern set, ordered specific → env-var → high-entropy:

| # | Pattern | Notes |
|---|---|---|
| 1-3 | \`sk_live_\`, \`sk_test_\`, \`pk_(live\\|test)_\` | Stripe |
| 4 | \`xox[baprs]-\` | Slack |
| 5 | \`(ghp_\\|gho_\\|github_pat_)\` | GitHub PAT |
| 6 | \`AKIA[0-9A-Z]{16}\` | AWS access key |
| 7 | \`Bearer\\s+[A-Za-z0-9._-]+\` | preserves \"Bearer\" word, masks value |
| 8 | \`sk-(ant-)?[A-Za-z0-9_-]{20,}\` | OpenAI / Anthropic |
| 9-10 | CPF / CNPJ | Brazilian PII |
| 11 | \`\\b[A-Z][A-Z0-9_]*=(...){8,}\` | env-var assignments, replacer keeps \`KEY=\` |
| 12 | \`\\b[A-Za-z0-9+/=_-]{32,}\\b\` | high-entropy base64-ish fallback |

Replacement: full match → \`***\` (or \`Bearer ***\`). Order matters — high-entropy would otherwise eat structured tokens.

### Fail-closed

If a regex throws on adversarial input (catastrophic backtrack), the error bubbles. The relay fails, Claude's permission_request times out per its own logic, **and nothing leaks**. Documented in the helper comment.

### \"Always\" ack scrub (server.ts:1344-1357 in this PR)

The \`(\${pending.pattern})\` suffix is removed from the ack at L1374 (was L1330). Internal state (\`pendingPermissions\`, \`sessionAllowPatterns\`) still stores plain pattern strings for the auto-allow check at L893 — patterns no longer cross the WhatsApp surface, so hashing has no security benefit and the round-1 hashing-as-mitigation collapsed.

## Probe (21/21 pass on shape branch)

\`\`\`
=== render-body-fixture ===
PASS  R-1: body has no occurrence of \"input_preview\"
PASS  R-1: body has no occurrence of \"tool_input\"
PASS  R-2: body has no Bash:* pattern literal
PASS  R-2: \"Always\" line is the generic phrase
PASS  R-3: sk_live token is masked
PASS  R-3: STRIPE_KEY assignment value is masked (env-var regex)
PASS  Body still has tool_name decorator
PASS  Body still has contextLine
PASS  Body still has request_id (for user reference)
PASS  Body still has the description with secret masked
PASS  Body length within Cloud API 1024 limit
PASS  Sanitizer masks sk_live_xyz123abc...
PASS  Sanitizer masks ghp_AbCdEfGhIjKlMnOpQrSt...
PASS  Sanitizer masks eyJhbGciOiJIUzI1NiJ9.eyJ...   (Bearer JWT)
PASS  Sanitizer masks AKIAIOSFODNN7EXAMPLE...
PASS  Sanitizer masks sk-ant-api03-LqXXXXXXXXX...
PASS  Sanitizer masks xoxb-1234-5678-abcdef-so...
PASS  Sanitizer masks 123.456.789-00...           (CPF)
PASS  Sanitizer masks 12.345.678/0001-90...       (CNPJ)
PASS  Sanitizer masks bGFyZ2VfYmFzZTY0X2VuY29k...  (high-entropy)
PASS  Benign body unchanged by sanitizer
\`\`\`

Spike at \`docs/shaping/v0.1.6-security-hotfix/pr4/spikes/render-body-fixture.ts\` (committed on shape branch / PR #16).

## Static gates

- **Typecheck**: \`bunx tsc --noEmit -p tsconfig.json\` exit 0
- **Single-path**: full replacement, no flag, no compat
- **No new \`any\`**: \`SECRET_PATTERNS\` typed as \`Array<[RegExp, string | ((m: string) => string)]>\`; \`sanitizeSecrets(text: string): string\`
- **Grep audit**:
  - \`rg 'input_preview' server.ts\` shows 9 matches — all in non-outbound contexts (schema field, destructuring, internal helpers \`permissionPattern\`/\`resolveInboundForPermission\`/\`isInternalWork\`, my own comment). **Zero flow into the body string.**
  - \`rg '\\\${pattern}' server.ts\` shows 1 match at L939 (a \`log()\` call to stderr / plugin.log — operator-internal, not WhatsApp). Body construction at L962-979 references \`tool_name\`, \`description\`, \`request_id\`, \`contextLine\` only.

## Diff scope

| Block | Change | LOC |
|---|---|---|
| \`SECRET_PATTERNS\` + \`sanitizeSecrets\` helper | new | +40 |
| Body construction (L962-979) | drop preview, drop pattern literal, generic \"Always\" line, sanitizer call | +5 / −7 |
| \"Always\" ack (L1344-1374) | drop \`ackSuffix\` variable + suffix | +4 / −6 |

Total: +57 / −13 = ~44 net LOC, single file.

## Manual probe (Reinaldo, at review)

Trigger 5 representative permission requests against +55 61 98559-8585 and confirm each rendered body is (a) leak-free, (b) informative enough to decide Allow/Always/Cancelar:

- [ ] **Bash with secret env**: e.g., a \`curl\` that needs \`STRIPE_KEY=\"sk_live_TEST_xyz\"\` (use a sandbox/test key). Body should not contain \`sk_live_\`, \`STRIPE_KEY=sk_\`, or any quoted value.
- [ ] **Bash benign**: \`git status\` or \`bun install\`. Body should look natural with no \`***\` artifacts.
- [ ] **Edit**: editing any file. Body should show the path and tool_name without input_preview JSON noise.
- [ ] **Write**: writing any file. Same as Edit.
- [ ] **Bash with file path containing PII** (e.g., \`/tmp/cliente-123.456.789-00.pdf\`). CPF should be masked to \`***\`.

If any class of tool calls feels uninformative, ledger the renderer enhancement for v0.2.x — PR4 doesn't pre-solve this; it ships the leak-free baseline.

## Known limitation (documented in evidence.md)

Lowercase env-style with short value — e.g., \`password: hunter2\` or \`token: abc12345\` (<32 chars) — escapes both the env-var regex (requires uppercase + underscore + value ≥8) and the high-entropy fallback (requires ≥32 chars). Trade-off accepted for v0.1.6; tracked for v0.2.x sanitizer evolution.

## Part of v0.1.6 release plan

This is **PR 5 of 6**, and the **last v0.1.6 blocker**. After this merges, PR6 (#6 \`activeTask\` TTL — optional, cuttable) is all that's between v0.1.5 and the v0.1.6 tag. Sequence: PR5 (#3 ✓ merged) → PR1 (#1, #19) → PR2 (#2, #20) → PR3 (#4+#5, #21) → **PR4 (this) → PR6 (#6)**. Tracking: #16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)