### PR TITLE
fix: expire activeTask after 5 min TTL (#6)

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -68,12 +68,19 @@ let lastActiveChatId: string | null = null
 
 // Active task: set when a WhatsApp message is delivered to Claude, cleared
 // when Claude calls `reply` for that phone. Used for permission attribution.
+// Also bounded by `expiresAt` (5 min after inbound) so a permission_request
+// arriving long after a forgotten conversation can't still be attributed
+// "During conversation with X" — that misattribution was a social-engineering
+// vector. After expiry the relay falls back to "Internal work".
+const ACTIVE_TASK_TTL_MS = 5 * 60 * 1000
+
 let activeTask: {
   id: string
   phone: string
   relationship: Relationship
   pushName: string | null
   status: 'processing' | 'replied'
+  expiresAt: number
 } | null = null
 
 const WEBHOOK_PORT = Number(process.env.WHATSAPP_PORT ?? '3789')
@@ -907,10 +914,10 @@ mcp.setNotificationHandler(
       if (oldestKey) pendingPermissions.delete(oldestKey)
     }
 
-    // Attribution: based on activeTask (set by WhatsApp inbound, cleared by reply).
-    // No timeouts — the reply tool is the explicit end-of-task signal.
+    // Attribution: based on activeTask (set by WhatsApp inbound, cleared by reply
+    // or by 5min TTL expiry — see ACTIVE_TASK_TTL_MS).
     let contextLine = ''
-    if (activeTask && activeTask.status === 'processing') {
+    if (activeTask && activeTask.status === 'processing' && activeTask.expiresAt > Date.now()) {
       const who = activeTask.pushName || `+${normalizePhone(activeTask.phone)}`
       const tag = activeTask.relationship === 'prospect' ? ' _(prospect)_' : ''
       contextLine = `👤 During conversation with *${who}*${tag}\n_Task: ${activeTask.id}_\n\n`
@@ -1432,6 +1439,7 @@ async function processWebhookPayload(payload: unknown): Promise<void> {
             relationship: gateResult.relationship,
             pushName: msg.pushName,
             status: 'processing',
+            expiresAt: Date.now() + ACTIVE_TASK_TTL_MS,
           }
           // Evict entries older than 10 minutes
           const cutoff = Math.floor(Date.now() / 1000) - 600
@@ -1465,6 +1473,16 @@ loadAccess()
 // Watch APPROVED_DIR for entries left by /whatsapp:access pair, and send a
 // confirmation to each newly-approved sender.
 setInterval(checkApprovals, 5000).unref()
+
+// Clear expired activeTask so attribution doesn't stay attached to a stale
+// conversation. Read sites also check expiresAt defensively; this interval
+// just keeps the in-memory state honest between reads.
+setInterval(() => {
+  if (activeTask && activeTask.expiresAt <= Date.now()) {
+    log(`activeTask ${activeTask.id} expired (${ACTIVE_TASK_TTL_MS / 1000}s TTL)`)
+    activeTask = null
+  }
+}, 60_000).unref()
 
 // Connect MCP transport FIRST — must be ready before notifications
 const transport = new StdioServerTransport()


### PR DESCRIPTION
## Summary
- Add \`expiresAt\` field to \`activeTask\` (5 min after inbound)
- Permission attribution check now requires \`activeTask.expiresAt > Date.now()\`
- 60s \`setInterval\` clears stale entries proactively

Closes #6.

## Why this is load-bearing

\`activeTask\` is set when a WhatsApp message reaches Claude (server.ts:1429-1436) and only cleared when Claude calls \`reply\` for the same phone (server.ts:1109-1113 on \`main\`). If Claude pivots to internal work without replying — common pattern when the operator chats inside the same Claude session for unrelated tasks — every subsequent \`permission_request\` is still attributed \`👤 During conversation with X\`.

Two failure modes:

1. **Operator sees a familiar name** on a permission they wouldn't have approved otherwise (a real social-engineering vector if the prospect's pushName was set).
2. **Audit confusion** — plugin.log says \"task wa_NNN active\" hours after the conversation ended.

## Implementation

### Type extension (server.ts:71-83)

\`\`\`ts
const ACTIVE_TASK_TTL_MS = 5 * 60 * 1000

let activeTask: {
  id: string
  phone: string
  relationship: Relationship
  pushName: string | null
  status: 'processing' | 'replied'
  expiresAt: number
} | null = null
\`\`\`

### Set site (server.ts:1429-1436)
\`\`\`ts
activeTask = {
  id: \`wa_\${Date.now()}\`,
  phone,
  relationship: gateResult.relationship,
  pushName: msg.pushName,
  status: 'processing',
  expiresAt: Date.now() + ACTIVE_TASK_TTL_MS,
}
\`\`\`

### Read site (server.ts:912-918)
\`\`\`ts
if (activeTask && activeTask.status === 'processing' && activeTask.expiresAt > Date.now()) {
  // ... \"During conversation with X\"
} else {
  // ... \"Internal work\"
}
\`\`\`

The reply-handler clear at L1109-1113 left as-is — its job is to mark the task \`replied\` after Claude responds; if expired, the read sites already treat it as internal regardless of \`status\`.

### Cleanup interval (near other intervals at server.ts:1467+)
\`\`\`ts
setInterval(() => {
  if (activeTask && activeTask.expiresAt <= Date.now()) {
    log(\`activeTask \${activeTask.id} expired (\${ACTIVE_TASK_TTL_MS / 1000}s TTL)\`)
    activeTask = null
  }
}, 60_000).unref()
\`\`\`

\`.unref()\` matches the existing pattern at L1467 so the timer doesn't keep the process alive.

## Frozen-clock probe (8/8)

\`\`\`
PASS  fresh inbound → conversation
PASS  @ 4min → still conversation
PASS  @ 5m01s → internal (expired)
PASS  activeTask still in memory before cleanup runs
PASS  after cleanup → activeTask is null
PASS  replied status → internal even before TTL
PASS  new inbound after expiry → conversation again
PASS  expiresAt freshly set
\`\`\`

Probe script ran locally with frozen clock; logic verified against the implementation. (No \`bun:test\` harness in repo yet — tracked for v0.2.x.)

## Static gates

- **Typecheck**: \`bunx tsc --noEmit -p tsconfig.json\` exit 0
- **Single-path**: pure addition; no flag, no compat
- **No new \`any\`**: type extension explicit
- **S-DROP-G**: Security ✓ (closes attribution drift); Resilience ✓ (revert single-PR); Observability ✓ (\`log()\` line on expiry)

## Diff scope

| Block | Change | LOC |
|---|---|---|
| Type extension + TTL constant | +6 / −0 |
| Set site (1 spot) | +1 |
| Read site (1 spot) | +1 / −1 |
| Cleanup interval | +9 |

Total: +21 / −3 = ~18 net LOC, single file.

## Manual probe (Reinaldo, optional at review)

To observe the behavior without waiting 5min in real time, temporarily lower \`ACTIVE_TASK_TTL_MS\` to \`30 * 1000\` (30s) in a local checkout, then:

1. Send an inbound WhatsApp message to the WABA → trigger any Claude action that requests permission within 10s. Body should show \`👤 During conversation with ...\`.
2. Wait 60s, trigger another permission. Body should now show \`⚙️ _Internal work_\`.
3. Check \`plugin.log\` for \`activeTask wa_... expired (30s TTL)\`.

Restore TTL to 5min before merge.

## Part of v0.1.6 release plan

This is **PR 6 of 6** and the **final PR**. Optional per parent shape §9 — cuttable if appetite tightens. Decision: shipping. After this merges, all 6 v0.1.6 blockers + the optional PR6 are closed; v0.1.6 release tag can be cut.

Sequence: PR5 (#3 ✓ merged) → PR1 (#1, #19) → PR2 (#2, #20) → PR3 (#4+#5, #21) → PR4 (#15, #22) → **PR6 (this)**. Tracking: #16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)