### PR TITLE
release: v0.1.7 — plugin.json metadata sync

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,15 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "whatsapp",
   "description": "WhatsApp channel for Claude Code — messaging bridge with built-in access control. Manage pairing, allowlists, and policy via /whatsapp:access.",
-  "version": "0.1.5",
+  "version": "0.1.7",
+  "author": {
+    "name": "RIA Systems",
+    "email": "suporte@riasistemas.com.br"
+  },
+  "homepage": "https://github.com/riasistemas/claude-channel-whatsapp",
+  "repository": "https://github.com/riasistemas/claude-channel-whatsapp",
+  "license": "Apache-2.0",
   "keywords": [
     "whatsapp",
     "messaging",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this plugin are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.7] — 2026-04-29
+
+Metadata sync release. No behavioral changes.
+
+### Changed
+
+- `.claude-plugin/plugin.json` was previously stuck at `0.1.5` while
+  `package.json`, the git tag `v0.1.6`, and the CHANGELOG had moved on.
+  Per the [plugin manifest schema](https://code.claude.com/docs/en/plugins-reference#plugin-manifest-schema),
+  if `version` is set in `plugin.json`, that value wins over the
+  marketplace entry — so users on `0.1.5` could miss patch updates
+  including the `0.1.6` security release. This bump realigns all
+  three sources at `0.1.7`.
+- Enriched `.claude-plugin/plugin.json` with the canonical metadata
+  block (`$schema`, `author`, `homepage`, `repository`, `license`).
+  These were already present in the marketplace catalog
+  (`riasistemas/claude-plugins`) but missing from the plugin
+  manifest itself, so installs that bypass the marketplace lacked
+  attribution and license info.
+
 ## [0.1.6] — 2026-04-29
 
 Security hotfix release. Closes the v0.1.6 blockers from the external

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-channel-whatsapp",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "license": "Apache-2.0",
   "type": "module",
   "bin": "./server.ts",


### PR DESCRIPTION
## Summary

Realigns `.claude-plugin/plugin.json` with the rest of the release artifacts (`package.json`, git tag `v0.1.6`, CHANGELOG), and enriches the manifest with metadata fields that were previously only in the marketplace catalog.

**No behavioral changes.** Pure metadata.

## Why this matters

`plugin.json` was stuck at `0.1.5` while everything else in the v0.1.6 release moved on. Per the [plugin manifest schema](https://code.claude.com/docs/en/plugins-reference#plugin-manifest-schema):

> If [`version` is] also set in the marketplace entry, `plugin.json` wins.

So users on `0.1.5` could miss the security patches that landed in `0.1.6`. This PR closes that gap.

## What changed

| File | Change |
|---|---|
| `.claude-plugin/plugin.json` | `0.1.5` → `0.1.7` + add `$schema`, `author`, `homepage`, `repository`, `license` |
| `package.json` | `0.1.6` → `0.1.7` |
| `CHANGELOG.md` | new `[0.1.7]` section |

## Why bump to `0.1.7` (not `0.1.6`)

The tag `v0.1.6` already exists pointing at `bd0b80d` (the security hotfix bundle). Bumping to `0.1.7` keeps history immutable and gives this metadata fix a clean trail of its own.

## New plugin.json fields rationale

| Field | Source of truth |
|---|---|
| `$schema` | Enables editor autocomplete + validation per [docs](https://code.claude.com/docs/en/plugins-reference#plugin-manifest-schema) |
| `author` | Already in marketplace.json — mirrors here for installs that bypass the catalog |
| `homepage` / `repository` | Same — provides attribution at install time |
| `license` | Same — `Apache-2.0`, matches `LICENSE` and `package.json` |

## Post-merge steps

```sh
git fetch origin main
git tag -a v0.1.7 origin/main -m "v0.1.7 — metadata sync"
git push origin v0.1.7

gh release create v0.1.7 --repo riasistemas/claude-channel-whatsapp \
  --title "v0.1.7 — metadata sync" \
  --notes-from-tag
```

## Test plan

- [ ] CI typecheck passes
- [ ] After merge: tag visible at https://github.com/riasistemas/claude-channel-whatsapp/releases/tag/v0.1.7
- [ ] `curl -s https://raw.githubusercontent.com/riasistemas/claude-channel-whatsapp/main/.claude-plugin/plugin.json | jq .version` returns `"0.1.7"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)