### PR TITLE
ci: bump actions/checkout v4 → v5 (Node 24) (#18)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   typecheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: oven-sh/setup-bun@v2
       - run: bun install --frozen-lockfile
       - run: bunx tsc --noEmit -p tsconfig.json


### PR DESCRIPTION
## Summary
- Bump \`actions/checkout@v4\` → \`actions/checkout@v5\` in \`.github/workflows/ci.yml\`

Closes #18.

## Why
v4 runs on Node 20 — deprecated by GitHub Actions runners. Forced switch to Node 24 in June 2026; Node 20 removed September 2026 (per the [2025-09-19 changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). The CI annotation has been firing since v0.1.6.

v5 targets Node 24, is drop-in compatible, and silences the warning.

## Diff scope

| File | Change |
|---|---|
| \`.github/workflows/ci.yml\` | one-line: \`v4\` → \`v5\` |

## Test plan
- [ ] CI run on this PR completes typecheck successfully (proves v5 fetches the tree correctly)
- [ ] No deprecation warning in run summary

Part of #25 v0.2.0 hardening — Cluster B quick wins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)