### PR TITLE
fix: use crypto.randomInt for pairing codes (#9)

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -15,6 +15,7 @@ import { Database } from 'bun:sqlite'
 import { readFileSync, writeFileSync, readdirSync, mkdirSync, rmSync, existsSync, realpathSync } from 'fs'
 import { homedir } from 'os'
 import { basename, join, resolve, sep } from 'path'
+import { randomInt } from 'crypto'
 import { z } from 'zod'
 
 // ── Config ──────────────────────────────────────────────────────────────────
@@ -352,10 +353,13 @@ function pruneExpired(access: Access): boolean {
 
 function newPairingCode(): string {
   // 6-char code from a-km-z (no l/L to avoid confusion with 1/I).
+  // randomInt is CSPRNG-backed (Node's crypto module). Math.random is
+  // not — predictable enough that an attacker observing one issued
+  // code could narrow the next one's search space materially.
   const alphabet = 'abcdefghijkmnopqrstuvwxyz'
   let code = ''
   for (let i = 0; i < 6; i++) {
-    code += alphabet[Math.floor(Math.random() * alphabet.length)]
+    code += alphabet[randomInt(0, alphabet.length)]
   }
   return code
 }


### PR DESCRIPTION
## Summary
- Add \`import { randomInt } from 'crypto'\`
- Replace \`Math.floor(Math.random() * alphabet.length)\` with \`randomInt(0, alphabet.length)\` in \`newPairingCode()\` (server.ts:358)

Closes #9.

## Why
\`Math.random\` is not cryptographically secure. V8's xorshift128+ algorithm is reverse-engineerable from a handful of observed outputs — an attacker who saw one issued pairing code (e.g., a former employee) could narrow the next code's search space materially. Pairing codes gate plugin access in \`pairing\` mode (\`/whatsapp:access pair <code>\`), so they should ride the CSPRNG.

\`crypto.randomInt(0, n)\` returns a uniform integer in \`[0, n)\` backed by OpenSSL's RAND. Same alphabet (\`abcdefghijkmnopqrstuvwxyz\`, no \`l\` to avoid 1/I confusion) and same length (6). User-visible behavior unchanged.

## Diff scope

| File | Change |
|---|---|
| \`server.ts\` | +2 / −1: import \`randomInt\` + swap call site |

## Test plan
- [ ] CI typecheck passes
- [ ] Local probe: \`bun run -e 'import {randomInt} from \"crypto\"; for (let i=0;i<5;i++) console.log(Array.from({length:6}, () => \"abcdefghijkmnopqrstuvwxyz\"[randomInt(0,25)]).join(\"\"))'\` produces 5 distinct 6-char codes from the right alphabet

Part of #25 v0.2.0 hardening — Cluster B quick wins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)