### PR TITLE
fix: sanitize lowercase env-style secrets + Basic auth (#27)

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -217,11 +217,16 @@ const SECRET_PATTERNS: Array<[RegExp, string | ((m: string) => string)]> = [
   [/xox[baprs]-[A-Za-z0-9-]+/g, '***'],
   [/(ghp_|gho_|github_pat_)[A-Za-z0-9_]+/g, '***'],
   [/AKIA[0-9A-Z]{16}/g, '***'],
-  [/Bearer\s+[A-Za-z0-9._-]+/gi, 'Bearer ***'],
+  [/\b(Bearer|Basic)\s+[A-Za-z0-9._=+/-]+/gi, (m: string) => m.split(/\s+/)[0] + ' ***'],
   [/sk-(ant-)?[A-Za-z0-9_-]{20,}/g, '***'],
   [/\b\d{3}\.\d{3}\.\d{3}-\d{2}\b/g, '***'],
   [/\b\d{2}\.\d{3}\.\d{3}\/\d{4}-\d{2}\b/g, '***'],
   [/\b[A-Z][A-Z0-9_]*=("[^"]{8,}"|'[^']{8,}'|[^\s'"`;&|]{8,})/g, (m: string) => m.split('=')[0] + '=***'],
+  // Lowercase env-style with known secret-key vocabulary.
+  // Anchored on a closed list (password, token, api_key, secret, auth)
+  // to avoid masking benign assignments like `pass=true` or `auth=basic`.
+  // Value cutoff at 6 chars (vs 8 for uppercase) catches shorter tokens.
+  [/\b(pass(?:word)?|tokens?|api[_-]?keys?|secrets?|auth|credentials?)\s*[:=]\s*['"]?[^\s'"`;&|]{6,}['"]?/gi, (m: string) => m.replace(/(\s*[:=]\s*).+/, '$1***')],
   [/\b[A-Za-z0-9+/=_-]{32,}\b/g, '***'],
 ]
 


### PR DESCRIPTION
## Summary
- Replace Bearer-only regex with auth-scheme-agnostic version (\`Bearer\` + \`Basic\`)
- Add lowercase env-style regex anchored on a closed secret-key vocabulary

Closes #27.

## Why
PR #22's sanitizer (v0.1.6) masked uppercase env-vars (\`STRIPE_KEY=\"sk_live_...\"\`) but missed lowercase patterns. Documented as a known limitation in the v0.1.6 PR4 evidence.md.

Two patterns added/changed:

### Auth scheme (replacement)
- **Was**: \`/Bearer\s+[A-Za-z0-9._-]+/gi\` → \`Bearer ***\`
- **Now**: \`/\b(Bearer|Basic)\s+[A-Za-z0-9._=+/-]+/gi\` → \`<scheme> ***\` (replacer preserves the scheme word)

The character class also adds \`=\` and \`+\` to handle base64 padding in Basic auth values.

### Lowercase secret-key vocabulary (new)
\`\`\`ts
/\b(pass(?:word)?|tokens?|api[_-]?keys?|secrets?|auth|credentials?)\s*[:=]\s*['\"]?[^\s'\"\`;&|]{6,}['\"]?/gi
\`\`\`

Anchored on a closed vocabulary list. Why these specific keys:
- \`password\`/\`pass\` — universal
- \`token\`/\`tokens\` — generic API tokens
- \`api_key\`/\`api-key\`/\`apikey\` (via \`[_-]?\`) + plural — common service auth
- \`secret\`/\`secrets\` — generic
- \`auth\` — for cases like \`auth: Basic ...\` already partially handled by the Bearer/Basic regex
- \`credentials\` — git/aws-style

Value cutoff at **6 chars** (vs 8 for uppercase env-vars) catches shorter tokens. The closed vocabulary prevents masking benign code like \`pass=true\`, \`auth=basic\`, \`Run npm install\`.

## Probe (13/13 pass)

\`\`\`
PASS  want=mask password: hunter2supersecretpassword
PASS  want=mask password=hunter2
PASS  want=mask token: abc123xyz
PASS  want=mask api_key=foobar123
PASS  want=mask secret: 'mySecret123'
PASS  want=mask auth: Basic dGVzdA==
PASS  want=mask Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.abc
PASS  want=mask credentials=verylongbase64stringhere
PASS  want=keep pass=true
PASS  want=keep auth=basic
PASS  want=keep Run npm install
PASS  want=keep git status
PASS  want=mask STRIPE_KEY=\"sk_live_xyz123abc\"   (regression check — uppercase still works)
\`\`\`

## Static gates
- **Typecheck**: \`bunx tsc --noEmit -p tsconfig.json\` exit 0
- **No regression on v0.1.6 patterns**: STRIPE_KEY uppercase case still masked

## Diff scope
| File | Change | LOC |
|---|---|---|
| \`server.ts\` | Bearer regex replaced + new lowercase regex | +6 / −1 |

## Follow-ups for the bun:test harness MF (#28)
Once #28 lands, the inline probe script becomes a proper test file. The 13 cases above are the seed.

Part of #25 v0.2.0 hardening — Cluster B quick wins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)