### PR TITLE
fix: sanitize pushName before relay body interpolation (#11)

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -225,6 +225,29 @@ const SECRET_PATTERNS: Array<[RegExp, string | ((m: string) => string)]> = [
   [/\b[A-Za-z0-9+/=_-]{32,}\b/g, '***'],
 ]
 
+/**
+ * Sanitize an attacker-controlled display name (`pushName`) before
+ * interpolating into the permission relay body. WhatsApp users pick
+ * their own profile name, so the value can contain:
+ * - WhatsApp markdown (`*bold*`, `_italic_`, `~strike~`, `` `code` ``)
+ *   that confuses the operator's view of the relay body.
+ * - Zero-width / BIDI override chars that homograph the surrounding
+ *   prose ("During conversation with *Reinaldo*" mimicking).
+ * - Control chars or absurdly long names (rate limit at 32 chars).
+ *
+ * Returns empty string when the input is null/empty/all-stripped, so
+ * the caller can fall back to the phone display.
+ */
+function sanitizeDisplayName(name: string | null | undefined): string {
+  if (!name) return ''
+  return name
+    .replace(/[\x00-\x1f\x7f]/g, '')
+    .replace(/[\u200B-\u200F\u202A-\u202E\u2066-\u2069]/g, '')
+    .replace(/[*_~`]/g, '')
+    .slice(0, 32)
+    .trim()
+}
+
 function sanitizeSecrets(text: string): string {
   let out = text
   for (const [re, replacer] of SECRET_PATTERNS) {
@@ -1042,7 +1065,7 @@ mcp.setNotificationHandler(
     // or by 5min TTL expiry — see ACTIVE_TASK_TTL_MS).
     let contextLine = ''
     if (activeTask && activeTask.status === 'processing' && activeTask.expiresAt > Date.now()) {
-      const who = activeTask.pushName || `+${normalizePhone(activeTask.phone)}`
+      const who = sanitizeDisplayName(activeTask.pushName) || `+${normalizePhone(activeTask.phone)}`
       const tag = activeTask.relationship === 'prospect' ? ' _(prospect)_' : ''
       contextLine = `👤 During conversation with *${who}*${tag}\n_Task: ${activeTask.id}_\n\n`
     } else {


### PR DESCRIPTION
## Summary
- Add \`sanitizeDisplayName(name)\` helper near other helpers
- Wrap \`activeTask.pushName\` at \`server.ts:1045\` (post-PR4) before interpolating into the permission body's \"During conversation with *...*\" line

Closes #11.

## Why
\`pushName\` is set by the WhatsApp user — the plugin reads it from the inbound webhook payload (\`server.ts:466\`) and stores it on \`activeTask\`. It then renders into the permission relay body as Markdown bold (\`*\${who}*\`). With no escaping, three attack vectors:

1. **Markdown injection**: a name like \`*Reinaldo* — APPROVED\` renders as confusing/misleading Markdown in the operator's WhatsApp view.
2. **BIDI / zero-width homograph**: a name with U+202E (RTL override) or U+200B (zero-width space) can mimic surrounding prose.
3. **Length DoS**: an arbitrarily long pushName eats the body's 1024-char Cloud API budget; the existing \`trimmedBody\` slice would chop the suffix (\`_ID: ...\` line), losing the request_id.

## Implementation

\`\`\`ts
function sanitizeDisplayName(name: string | null | undefined): string {
  if (!name) return ''
  return name
    .replace(/[\\x00-\\x1f\\x7f]/g, '')
    .replace(/[\\u200B-\\u200F\\u202A-\\u202E\\u2066-\\u2069]/g, '')
    .replace(/[*_~\`]/g, '')
    .slice(0, 32)
    .trim()
}
\`\`\`

What's stripped:
- **Control chars** \`\\x00-\\x1f\\x7f\` — non-printable.
- **Zero-width + BIDI override** ranges — \`\\u200B-\\u200F\` (ZWSP, ZWNJ, ZWJ, LRM, RLM) and \`\\u202A-\\u202E\` (LRE, RLE, PDF, LRO, RLO) and \`\\u2066-\\u2069\` (LRI, RLI, FSI, PDI).
- **WhatsApp markdown chars** \`*_~\`\` — these format text in WhatsApp; stripping them prevents bold/italic/strike/code injection.
- **Length truncation** at 32 chars — accommodates real-world names (\"João Silva Carvalho de Oliveira\" = 32 chars; longer = truncated).
- **Trim** — handles trailing whitespace post-stripping.

If the result is empty (input was null, empty, or all-formatting), the call site falls back to \`+\${normalizePhone(activeTask.phone)}\` — same behavior as before for empty pushName.

## Probe (15/15 pass)

\`\`\`
PASS  \"Reinaldo\"           → \"Reinaldo\"          (legitimate name)
PASS  \"João Silva\"         → \"João Silva\"        (accents preserved)
PASS  \"*evil*\"             → \"evil\"              (markdown stripped)
PASS  \"_underline_\"        → \"underline\"
PASS  \"~strike~\"           → \"strike\"
PASS  \"\`code\`\"             → \"code\"
PASS  \"*Reinaldo*\"         → \"Reinaldo\"          (homograph attempt)
PASS  50-char input         → 32-char output     (truncation)
PASS  \"abc<ZWSP>def\"       → \"abcdef\"            (zero-width)
PASS  \"<RLO>eviL\"          → \"eviL\"              (BIDI override)
PASS  \"  spaced  \"         → \"spaced\"            (trim)
PASS  \"\\x00\\x01abc\"        → \"abc\"               (control chars)
PASS  null                  → \"\"                  (fallback to phone)
PASS  \"\"                    → \"\"                  (fallback to phone)
PASS  \"***\"                → \"\"                  (all-formatting → fallback)
\`\`\`

## Static gates
- **Typecheck**: \`bunx tsc --noEmit -p tsconfig.json\` exit 0
- **No regression**: existing fallback to phone display (\`|| \\\`+\\\${normalizePhone(...)}\\\`\`) unchanged

## Diff scope
| File | Change | LOC |
|---|---|---|
| \`server.ts\` | new helper + 1-line call site wrap | +25 / −1 |

Part of #25 v0.2.0 hardening — Cluster B quick wins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)