### PR TITLE
Shape: v0.2.0 cycle — Cluster A + #10 + #28

### DIFF
--- a/docs/shaping/10-pattern-granularity/shaping.md
+++ b/docs/shaping/10-pattern-granularity/shaping.md
@@ -1,0 +1,239 @@
+# Shaping — #10 permission "Always" pattern granularity
+
+## §0 Status TOC
+
+| # | Section | Status | Notes |
+|---|---|---|---|
+| 1 | Micro feature | ✓ | refine `permissionPattern()` so "Always" doesn't auto-allow more than the user signed up for |
+| 2 | Problem | ✓ | `Bash:git` matches `git status` AND `git push origin main --force` |
+| 3 | Outcome | ✓ | re-prompt on dangerous variant after auto-allow on benign one |
+| 4 | Why now | ✓ | UX flaw in v0.1.6 `sessionAllowPatterns`; safe by default before plugin grows |
+| 5 | Monorepo scan | ✓ | single function (`permissionPattern`); 2 call sites |
+| 6 | Requirements | ✓ | granularity rule per chosen shape |
+| 7 | Candidate shapes | ◐ | **3 options — Reinaldo picks at bet** |
+| 8 | Selected shape | ○ | pending pick |
+| 9 | Appetite | ✓ | 0.5–1 day, depends on shape |
+| 10 | In/Out scope | ✓ | `permissionPattern` only |
+| 11 | Rabbit holes | ✓ | 3 risks |
+| 12 | S-DROP-G | ✓ | all decided |
+| 13 | Cutover | ✓ | A (narrow fits) |
+| 14 | Pair shaping | ✓ | async — but bet decision needs Reinaldo's pick on §7 |
+| 15 | Breadboard | ✓ | one function rewrite |
+| 16 | Build scopes | ✓ | single scope, depends on §7 pick |
+| 17 | Gate verification | ✓ | passes per shape |
+| 18 | Bet | ○ | awaiting Reinaldo's §7 pick |
+
+**Siblings:** evidence.md · spikes/
+
+---
+
+## §1 Micro feature
+
+Refine the `permissionPattern()` function at `server.ts:809-830` so the "🔁 Always" auto-allow scope is closer to user intent. Today, tapping "Always" on a permission for `git status` auto-approves *all* `git` invocations including destructive ones.
+
+## §2 Problem
+
+Current implementation (post-v0.1.6, server.ts:809-830):
+
+```ts
+function permissionPattern(
+  tool_name: string,
+  description: string,
+  input_preview: string,
+): string {
+  if (tool_name === 'Bash') {
+    // First token of the command: `ls`, `git`, `curl`, ...
+    const cmdMatch = /^\s*([^\s|;&]+)/.exec(input_preview)
+    return `Bash:${cmdMatch?.[1] || '*'}`
+  }
+  // ... non-Bash: extract longest path's dir
+}
+```
+
+Bash patterns are derived from the **first token** only. Concrete consequences:
+
+| First request | Always-tap auto-approves later |
+|---|---|
+| `git status` | `git push origin main --force` |
+| `npm install` | `npm publish` |
+| `curl https://api.example.com/health` | `curl -X POST $UNTRUSTED_URL` |
+| `rm /tmp/scratch.log` | `rm -rf ~/.ssh` |
+
+For non-Bash tools the pattern is the dir of the longest extracted path — also coarse. `Edit` on `/Users/luoarch/notes/today.md` auto-approves all future `Edit` operations under `/Users/luoarch/notes/`, which is mostly fine but still surprises operators when they tap Always on a notes edit and find Claude later editing config there.
+
+The leak surface from #15 is closed (PR #22 stripped the pattern from the WhatsApp body) but the **scope of consent** the operator is granting via "Always" is still coarser than the visible request. The body shows `git status`; the auto-allow rule that gets stored is `Bash:git`.
+
+## §3 Outcome
+
+Observable success metric (per chosen shape — see §7):
+
+- **Shape A (specific)**: tapping Always on a `git status` permission later re-prompts on `git push --force` (different second token).
+- **Shape B (granular by safe-flag list)**: tapping Always on `git status` auto-approves `git status -s`, `git diff`, `git log` but re-prompts on `git push`/`git reset`/`git rm`.
+- **Shape C (drop "Always")**: every permission is single-shot; nothing to test about scope.
+
+Probe per shape lives in `spikes/`.
+
+## §4 Why now
+
+This is the residual UX flaw from the v0.1.6 permission relay redesign. Surfaced in PR #22 review but explicitly deferred (parent shape §10) to v0.2.x. Now is the time before:
+- Plugin gets distributed widely (marketplace) and the coarse-Always behavior surprises new users.
+- Anyone bumps into a real near-miss (operator taps Always on `npm install` to skip approvals, Claude later runs `npm publish`).
+
+## §5 Monorepo scan
+
+Single function (`permissionPattern`), two call sites:
+- `server.ts:914` — handler at permission_request notification: computes pattern, checks `sessionAllowPatterns.has(pattern)` for auto-allow, stores in `pendingPermissions`.
+- `server.ts:1334` — reply handler: when user taps "Always", reads `pendingPermissions.get(request_id).pattern` and adds to `sessionAllowPatterns`.
+
+No external consumer of the pattern string (closed by PR #22 — pattern stays in-process). No persistence (in-memory Set; clears on plugin restart).
+
+Constraints:
+- Pattern strings are opaque to the user — they don't see them in the body, just behavior.
+- `sessionAllowPatterns` is a `Set<string>` — exact-match lookup. Any change to the format changes lookup semantics; no per-existing-entry compatibility shim needed since restarts clear the set.
+
+## §6 Requirements
+
+Depend on §7 pick. Common to all shapes:
+- The function rewrite must keep the `permissionPattern(tool_name, description, input_preview): string` signature so call sites at L914 and L1334 don't change.
+- Lookup behavior unchanged: same string → same allow.
+- v0.1.6 in-memory state invalidates on next restart (no migration).
+
+Per-shape:
+- **Shape A (specific)**: Bash pattern includes first AND second token (or as many tokens as are non-flag, non-quoted). E.g., `git status` → `Bash:git status`; `git push origin main --force` → `Bash:git push`.
+- **Shape B (granular by safe-flag list)**: Bash pattern carries the verb + a safe/unsafe classification token. E.g., `git status` → `Bash:git:safe`; `git push --force` → `Bash:git:unsafe`. Maintains a small allowlist of safe verbs per command (`git: status, diff, log, show; npm: list, view, info; curl: GET-only`).
+- **Shape C (drop "Always")**: remove `sessionAllowPatterns`, drop "Always" button from interactive buttons, simplify reply handler. Single-shot every time. Permission body shows 2 buttons (Allow / Cancelar).
+
+## §7 Candidate shapes — REINALDO PICKS
+
+### Shape A — first 2 tokens
+- **Pattern format**: `Bash:<verb> <subverb>` (e.g., `Bash:git status`, `Bash:git push`); fall back to `Bash:<verb>` if there's only one token; non-Bash: pattern = `<tool>:<dir>` UNCHANGED.
+- **LOC**: ~5 in `permissionPattern` body. Trivial.
+- **UX**: tap Always on `git status` → re-prompts on `git push`. Tap Always on `npm install` → re-prompts on `npm publish`. Generally matches user intent.
+- **Failure modes**:
+  - Two-token still too coarse for `curl` (different URLs are different intent but both might be "GET"). Acceptable for now — `curl` is one example, not the rule.
+  - Subverb after `--` (e.g., `npm run -- test`) makes pattern weird. Edge case.
+- **Recommended if**: Reinaldo wants a one-step UX improvement without changing the mental model.
+
+### Shape B — verb + safe/unsafe classification
+- **Pattern format**: `Bash:<verb>:<safe|unsafe>` (e.g., `Bash:git:safe`, `Bash:git:unsafe`); subverb classified via per-verb safe-list.
+- **Safe-list (illustrative; tune at impl time)**:
+  ```ts
+  const SAFE_VERBS: Record<string, Set<string>> = {
+    git: new Set(['status', 'diff', 'log', 'show', 'branch', 'remote']),
+    npm: new Set(['list', 'view', 'info', 'outdated', 'audit']),
+    bun: new Set(['list', 'pm']),
+    docker: new Set(['ps', 'inspect', 'logs', 'images']),
+    // ...
+  }
+  ```
+- **LOC**: ~30 (the safe-list + the classifier).
+- **UX**: tap Always on `git status` → auto-approves `git diff`, `git log`, `git branch`, but re-prompts on `git push`. Operator effectively grants "all read-only git ops" in one tap. Higher utility than A.
+- **Failure modes**:
+  - Maintenance burden — the safe-list is opinionated, can drift. New tools (e.g., a custom CLI) default to "everything unsafe" until added.
+  - Pattern category leakage — adversarial user could find a safe verb that has destructive flags (`git diff --output=/etc/passwd`? probably not but illustrates the principle).
+- **Recommended if**: Reinaldo wants more thoughtful auto-allow scoping and is OK maintaining the safe-list.
+
+### Shape C — drop "Always" entirely
+- **Pattern format**: N/A; `permissionPattern` deleted; `sessionAllowPatterns` deleted.
+- **LOC**: ~50 LOC removed; ~5 LOC added (button list shrinks).
+- **UX**: every permission re-prompts. Aligns with `anthropics/claude-plugins-official` telegram + imessage (neither has "Always"). Eliminates the entire scope-of-consent concern.
+- **Failure modes**:
+  - Operator fatigue — every `git status` re-prompts. In a long Claude session this gets annoying fast.
+- **Recommended if**: Reinaldo concluded the marketplace audience values security-by-default over UX convenience, and the absence of "Always" matches what other plugins do.
+
+### Recommendation
+
+**Shape A** as the default — minimal change, clear UX win, maintains the "Always" ergonomics. Shape B if the maintenance burden of a small safe-list feels worth it for the marketplace polish. Shape C only if the design philosophy has shifted entirely (which would warrant its own discussion before bet).
+
+## §8 Selected shape
+
+Pending Reinaldo's §7 pick. Until that's recorded, §18 Bet stays open.
+
+## §9 Appetite
+
+- **Shape A**: 0.5 day. Single function rewrite + spike.
+- **Shape B**: 1 day. Function rewrite + safe-list curation + spike + manual probe.
+- **Shape C**: 0.5 day. Mostly deletion + button-list trim.
+
+## §10 In-scope / Out-of-scope
+
+### In-scope
+- `permissionPattern()` rewrite (server.ts:809-830)
+- Spike updating `sessionAllowPatterns` lookup matching the new format
+- Per-shape changes in `pendingPermissions` storage if needed (probably none — value is a string either way)
+
+### Out-of-scope
+- [no-go] **Persist `sessionAllowPatterns` across plugin restarts** — separate MF (data migration concerns)
+- [no-go] **User-visible pattern rendering** — closed by PR #22; we don't surface patterns in the body anymore
+- [no-go] **"Allow this command for X minutes" TTL on patterns** — separate MF
+- Mention of patterns in plugin.log — out of scope (operator-internal)
+
+## §11 Rabbit holes
+
+### R-1: Shape B safe-list curation drift
+- **Category**: maintenance
+- **Mitigation**: ship a v0.2.x version with a conservative safe-list (only obviously read-only ops); evolve via small PRs. The safe-list lives in source, so reviewable per-change.
+- **Layer**: code review (not test)
+
+### R-2: Existing in-memory state invalidates
+- **Category**: minor user-visible change at upgrade
+- **Evidence**: `sessionAllowPatterns` is `Set<string>` in-memory; plugin restart clears it. v0.2.0 launch = fresh restart = fresh set. Operator re-taps Always once after upgrade. Documented in CHANGELOG.
+- **Layer**: docs
+
+### R-3: Spike fixture covers all 3 shapes consistently
+- **Category**: shape evidence
+- **Evidence**: `spikes/pattern-fixture.ts` defines 12 representative request inputs and asserts the expected pattern per shape. Run with `bun run spikes/pattern-fixture.ts -- A` (or `B`/`C`). Status: spike skeleton committed; per-shape outputs filled when shape is selected.
+
+## §12 S-DROP-G
+
+- **Security**: addressed — narrowing auto-allow scope is purely security-positive. AuthZ unchanged.
+- **Data**: N/A — in-memory only.
+- **Resilience**: revert via single PR.
+- **Observability**: existing `log()` line at server.ts:939 (`auto-allow ${request_id} (session pattern: ${pattern})`) keeps working with the new format.
+- **Platform**: no infra change.
+- **Governance**: owner = Reinaldo. Kill-the-bet: defer to v0.3 if appetite tightens; current behavior is "works but coarse," not broken.
+
+## §13 Cutover decision
+
+**A (narrow fits)**. Single function, no compat path, in-memory state that resets on restart.
+
+## §14 Pair shaping
+
+Async — Reinaldo's §7 pick is the only synchronous decision needed; can be a comment on this shape's PR or a verbal "go with A".
+
+## §15 Breadboard
+
+```
+Claude → permission_request → handler
+  │
+  ├─ pattern = permissionPattern(tool_name, description, input_preview)
+  │     [SHAPE A]: Bash → first 2 tokens
+  │     [SHAPE B]: Bash → verb + safe/unsafe class
+  │     [SHAPE C]: function deleted; pattern logic removed
+  │
+  ├─ if [shape ≠ C] sessionAllowPatterns.has(pattern):
+  │     auto-allow
+  │
+  └─ else:
+        send body with N buttons
+        (N=3 for A/B; N=2 for C — Allow / Cancelar)
+```
+
+## §16 Build scopes
+
+Single scope. Spec-first via spike (`spikes/pattern-fixture.ts`).
+
+- **change_type**: `new-rule`
+- **required_test_layers**: `[static, unit (fixture)]`
+- **evidence_plan**: 12 representative input cases per shape; assert pattern output matches expected; lookup round-trip (`Set.add` → `Set.has`) validates exact-match semantics.
+
+## §17 Gate verification (pre-bet)
+
+All gates pass per any selected shape — single function, single-path, type-safe. Differs only in code volume.
+
+## §18 Bet
+
+- **Decision**: pending — needs Reinaldo §7 pick.
+- **Approver**: Reinaldo via comment on shape PR.
+- **Recommended default**: A.
+- **Once §7 picked**: this shape locks the §16 build scope per the chosen shape, then `/build` runs.

--- a/docs/shaping/28-bun-test-harness/evidence.md
+++ b/docs/shaping/28-bun-test-harness/evidence.md
@@ -1,0 +1,55 @@
+# Evidence — #28 bun:test harness
+
+## R-1: import.meta.main gate covers all side-effects
+- Layer: static + unit
+- Evidence type: spike `spikes/import-meta-probe.ts` (run before /build)
+- Status: pending pre-bet
+- Plan: probe imports server.ts via `import { sanitizeSecrets } from '../server.ts'` from a test-style file (no `Bun.run` of server.ts) and asserts:
+  - `acquireLock` not called (lockfile not created in tmpdir)
+  - `Bun.serve` not called (no listener on WEBHOOK_PORT)
+  - `mkdirSync(STATE_DIR)` not called (no state dir creation)
+  - `requireEnv` not called (no env-var validation; no `process.exit`)
+- Mitigation if fails: extract to explicit `bootstrap()` function called from `if (import.meta.main) bootstrap()` block.
+
+## R-2: CI runtime overhead
+- Layer: timing observation
+- Status: complete
+- Bun's native test runner clocks under 1s for typical unit-test suites with no I/O. The bootstrap suite (~50 unit assertions) is expected to run in well under 5s. CI total run rises from ~30s to ~35s — acceptable.
+
+## R-3: Test isolation for fs-touching helpers
+- Layer: unit fixture template
+- Status: complete (designed)
+- Pattern documented in `tests/assert-sendable.test.ts` skeleton:
+  ```ts
+  import { describe, it, expect, beforeAll, afterAll } from 'bun:test'
+  import { mkdirSync, rmSync } from 'fs'
+  import { tmpdir } from 'os'
+  import { join } from 'path'
+  
+  const TEST_STATE = join(tmpdir(), `whatsapp-test-${Date.now()}`)
+  
+  beforeAll(() => {
+    mkdirSync(join(TEST_STATE, 'media'), { recursive: true })
+    process.env.WHATSAPP_STATE_DIR = TEST_STATE
+  })
+  afterAll(() => rmSync(TEST_STATE, { recursive: true, force: true }))
+  ```
+- Tests use real filesystem (in tmpdir), real regex, real helpers — no mocks.
+
+## TPG anti-pattern lens
+- "All tests pass with no integration proof" — addressed for the helpers we test. Integration (HTTP through to MCP notification) is a separate MF.
+- "Heavy mocks" — explicitly avoided. Helpers are pure functions or fs-touching with real tmp paths.
+
+## Migration of v0.1.6 spike fixtures
+| Spike file | Coverage | Migrates to | LOC delta |
+|---|---|---|---|
+| `pr4/spikes/sanitize-fixture.ts` (12 cases) | sanitizeSecrets | `tests/sanitize.test.ts` | ~−90 + ~+120 |
+| `pr4/spikes/render-body-fixture.ts` (21 cases) | renderPermissionBody | `tests/render-permission-body.test.ts` | ~−140 + ~+170 (V2) |
+| (inline in PR2 body, 12 cases) | safeMediaPath | `tests/safe-media-path.test.ts` | new file ~120 LOC |
+| (inline in PR3 body, 7 cases) | assertSendable | `tests/assert-sendable.test.ts` (V2) | new file ~80 LOC |
+| (inline in PR4 body, 4 cases) | assertSendablePhone | included in `tests/assert-sendable.test.ts` (V2) | +~40 LOC |
+| (inline in PR #31 body, 13 cases) | sanitizeSecrets lowercase variants | merged into `tests/sanitize.test.ts` | +~30 LOC |
+| (inline in PR #32 body, 15 cases) | sanitizeDisplayName | added to `tests/sanitize.test.ts` | +~50 LOC |
+
+After V1: `pr4/spikes/sanitize-fixture.ts` deleted.
+After V2: `pr4/spikes/render-body-fixture.ts` deleted.

--- a/docs/shaping/28-bun-test-harness/shaping.md
+++ b/docs/shaping/28-bun-test-harness/shaping.md
@@ -1,0 +1,294 @@
+# Shaping — #28 establish bun:test harness
+
+## §0 Status TOC
+
+| # | Section | Status | Notes |
+|---|---|---|---|
+| 1 | Micro feature | ✓ | bootstrap `bun:test` + migrate v0.1.6 spike fixtures into real tests |
+| 2 | Problem | ✓ | every PR ships fixture-style spike scripts; CI only typechecks |
+| 3 | Outcome | ✓ | `bun test` green in CI + 4 helper modules covered |
+| 4 | Why now | ✓ | unblocks proper tests for Cluster A (#7+#8+#12) and #10 |
+| 5 | Monorepo scan | ✓ | server.ts is single-file; helpers are module-scope; CI workflow already exists |
+| 6 | Requirements | ✓ | runner choice + layout + export hooks + first batch of tests |
+| 7 | Candidate shapes | ✓ | 1 selected (bun:test, sibling tests/, export module-scope helpers) |
+| 8 | Selected shape | ✓ | locked |
+| 9 | Appetite | ✓ | 1 day |
+| 10 | In/Out scope | ✓ | infra + 4 test files (sanitizeSecrets, safeMediaPath, assertSendable, renderPermissionBody) |
+| 11 | Rabbit holes | ✓ | 3 risks (export surface, CI runtime, assertSendable side effects) |
+| 12 | S-DROP-G | ✓ | all decided |
+| 13 | Cutover | ✓ | A (narrow fits) |
+| 14 | Pair shaping | ✓ | async |
+| 15 | Breadboard | ✓ | tests/ next to server.ts; CI adds 1 step |
+| 16 | Build scopes | ✓ | 2 scopes (V1: bootstrap + sanitizeSecrets test; V2: rest) |
+| 17 | Gate verification | ✓ | passes |
+| 18 | Bet | ○ | awaiting Reinaldo go-ahead |
+
+**Siblings:** evidence.md · spikes/
+
+---
+
+## §1 Micro feature
+
+Establish a `bun:test` runner so every future PR can ship spec-first tests instead of fixture-style spike scripts. Migrate the v0.1.6 spike fixtures (sanitize-fixture.ts 18/18, render-body-fixture.ts 21/21) into real tests as the bootstrap content.
+
+## §2 Problem
+
+The plugin currently has zero test runner. CI runs `bunx tsc --noEmit` only. Each PR in the v0.1.6 + Cluster B cycles shipped its own fixture-style probe (in `docs/shaping/.../spikes/` for the major ones; inline in PR descriptions for the trivial ones). This works but:
+
+- **Tests live in `docs/`, not `src/`** — disposable evidence, not durable contracts.
+- **Spikes duplicate production helpers** — `sanitize-fixture.ts` re-implements `sanitizeSecrets` to test the design; doesn't actually verify the production code stays in sync.
+- **CI doesn't run them** — no regression catch on next PR.
+- **Reviewers can't easily run them either** — they have to know which spike file to invoke.
+
+The v0.2.0 cycle is moving faster (5 PRs landed in Cluster B today) and Cluster A (webhook hardening) wants to ship a zod schema with proper validation tests. Without a real harness, Cluster A's evidence_plan stays at "manual probe at review" — fine, but the fixture-equivalent script lives in `docs/` again.
+
+## §3 Outcome
+
+Observable success metrics:
+
+1. `bun test` from repo root reports "X tests passed" — green exit 0.
+2. CI workflow (`.github/workflows/ci.yml`) gains a `bun test` step after typecheck. Both must pass on every PR.
+3. Four production helpers covered by tests (V1 bootstrap):
+   - `sanitizeSecrets` (12+ patterns from v0.1.6 spike + v0.2.0 lowercase env from PR #31)
+   - `safeMediaPath` (12 cases from v0.1.6 spike)
+   - `assertSendable` (file-path gate, canonical pattern with state/media carve-out)
+   - `assertSendablePhone` (phone gate, RIA-original)
+4. Tests live in `tests/` (sibling to `server.ts`).
+5. README "Development" section updated: `bun test` documented next to existing `bun update` flow.
+6. v0.1.6 spike directories (`docs/shaping/v0.1.6-security-hotfix/pr4/spikes/`) get a "deprecated, see tests/" note OR are deleted entirely once tests are green.
+
+## §4 Why now
+
+- **Unblocks Cluster A (#7+#8+#12)** — webhook-hardening shape proposes a zod schema and per-entry filter; both want unit tests. With the harness in place, those tests ship as `tests/webhook-schema.test.ts` instead of yet another spike script.
+- **Unblocks #10** — pattern granularity needs a fixture covering 3 candidate shapes against 12 inputs. Test-driven choice between A/B/C.
+- **Marketplace polish** — public plugins with real test suites read more credible than ones with spike scripts in `docs/`.
+
+## §5 Monorepo scan
+
+### Surface 1: `server.ts` (single file)
+Module-scope helpers that need to be reachable from tests:
+- `sanitizeSecrets` (server.ts:228 area)
+- `sanitizeDisplayName` (recently added, PR #32)
+- `safeMediaPath` (server.ts:540 area)
+- `assertSendable` (file gate, server.ts post-PR3 — call it `assertSendableFile` if confusable)
+- `assertSendablePhone` (phone gate)
+- `permissionPattern` (helps test #10 if/when that ships)
+
+Two paths to expose them:
+
+**Path α**: add `export` keywords to the helpers. Server still runs as a script (Bun's `bun server.ts` doesn't care about exports) but tests can `import` from `'../server'`.
+
+**Path β**: extract them to `lib/security.ts`, `lib/media.ts`, etc.
+
+Path α is the single-file design preserved (parent v0.1.6 §10 no-go list explicitly: "Refactor server.ts into modules — single-file is a deliberate architectural choice"). Adopting it means `tests/sanitize.test.ts` does:
+
+```ts
+import { sanitizeSecrets } from '../server.ts'
+```
+
+There's a side-effect at module-load (acquires lockfile, opens DB, starts http server). Tests need to short-circuit those.
+
+### Surface 2: `package.json` scripts
+Currently has `start` only. Need to add `test` (and `test:watch` if useful).
+
+### Surface 3: `.github/workflows/ci.yml`
+Adds one step after typecheck.
+
+### Surface 4: spike fixture files
+Once tests pass, the v0.1.6 spike files are obsolete. Either delete or annotate. Keep parent shape doc (`docs/shaping/v0.1.6-security-hotfix/shaping.md`) intact — it's historical.
+
+### Constraints
+- `server.ts` runs side-effectful code at top-level: `acquireLock()`, `requireEnv(...)` (which `process.exit(1)` on missing vars), `Bun.serve(...)`, `mkdirSync(STATE_DIR)`, etc. Importing `server.ts` from a test file would trigger all of this.
+- `requireEnv` calling `process.exit(1)` is the showstopper — running `bun test` without `WHATSAPP_*` env vars set would kill the test process.
+
+## §6 Requirements
+
+### R-1: runner = `bun:test`
+Native, zero-dep, ESM-friendly, matches the runtime. Vitest considered and rejected — adds `vite` + plugin deps; mismatch with Bun's native test runner; no compelling feature gap.
+
+### R-2: layout = `tests/` (sibling to `server.ts`)
+- `tests/sanitize.test.ts`, `tests/safe-media-path.test.ts`, `tests/assert-sendable.test.ts`, `tests/render-permission-body.test.ts`.
+- Future tests follow the same pattern.
+
+### R-3: server.ts side-effects guarded by entrypoint check
+- Wrap the side-effectful module-load code in `if (import.meta.main) { ... }` — Bun's idiom for "only run when invoked directly". When `bun test` imports `server.ts`, the body is type-checked but the side effects don't fire.
+- Alternative: extract everything into a `main()` function and gate the call site. More invasive.
+- **Selected**: `import.meta.main` gate. Leaves the file structure intact; the gate is one `if` block wrapping the bottom of the file.
+
+### R-4: helpers are exported
+- Add `export` to: `sanitizeSecrets`, `sanitizeDisplayName`, `safeMediaPath`, `assertSendable`, `assertSendablePhone`, `renderPermissionBody` (if extracted; today the body construction is inline in the handler — needs extraction for proper testing).
+- `permissionPattern` exported as part of the same batch (for future #10 work).
+
+### R-5: bootstrap test set covers V1
+- `tests/sanitize.test.ts` — port 12 v0.1.6 cases + 13 v0.2.0 lowercase env cases (from PR #31) + 15 displayName cases (from PR #32, since `sanitizeDisplayName` lives next door)
+- `tests/safe-media-path.test.ts` — port 12 v0.1.6 PR2 cases
+- `tests/assert-sendable.test.ts` — port 7 v0.1.6 PR3 file-gate cases + 4 phone-gate truth-table cases
+- `tests/render-permission-body.test.ts` — port 21 v0.1.6 PR4 render-body cases (requires §16 V1 to extract `renderPermissionBody` from the handler — small refactor, ~20 LOC)
+
+### R-6: CI integration
+- `.github/workflows/ci.yml` adds:
+  ```yaml
+  - run: bun test
+  ```
+  after the existing `bunx tsc --noEmit` step. Same job (typecheck → test).
+
+### R-7: README update
+- "Development" section gains a paragraph explaining `bun test`.
+
+## §7 Candidate shapes
+
+### Shape A — bun:test + tests/ + import.meta.main gate (recommended)
+- Native runner, sibling tests dir, in-place server.ts gate.
+- Single file stays single file.
+- ~150 LOC across 4 test files + ~10 LOC in server.ts (export keywords + import.meta.main gate + extract renderPermissionBody).
+
+### Shape B — Vitest + tests/ + extract helpers to lib/
+- Adds `vite` + plugin to devDependencies.
+- More refactor (extract helpers) — touches the no-go from parent shape.
+- More mature ecosystem (better watch mode, snapshot testing, etc.) but features we don't need.
+
+**Selected: Shape A.** Aligns with the "single-file deliberate" architectural choice and avoids new deps.
+
+## §8 Selected shape
+
+Locked: **Shape A** — `bun:test`, `tests/` sibling, `import.meta.main` gate, export helpers in place.
+
+## §9 Appetite
+
+- **Time-box**: 1 day.
+- **Circuit breaker**: if `import.meta.main` gating turns out to need more invasive surgery (e.g., the sql `db = new Database(DB_PATH)` at module-load is required by helpers we're testing), fall back to extracting the side-effect code into a `bootstrap()` function called from a tiny `if (import.meta.main) bootstrap()` at the bottom. Same external behavior, slightly bigger diff.
+- **Why time-box is enough**: existing fixtures port directly; main work is the gate + exports + CI step.
+- **Must-fit**: bootstrap (test runs), 4 test files, CI integration, README note.
+- **First cut**: V2 deferral — if tests for `assertSendable` or `renderPermissionBody` need more refactor than expected, ship V1 with sanitizer + safeMediaPath only and ledger the rest under #25.
+
+## §10 In-scope / Out-of-scope
+
+### In-scope
+- `package.json` `scripts.test` field
+- `.github/workflows/ci.yml` test step
+- `tests/` directory with 4 test files
+- `server.ts` minimal changes: export keywords + `import.meta.main` gate + `renderPermissionBody` extraction
+- README "Development" section update
+- Delete/annotate v0.1.6 spike directories once tests pass
+
+### Out-of-scope
+- [no-go] **Coverage tooling** (c8, istanbul, etc.) — separate MF if ever wanted.
+- [no-go] **Mock everything** — tests should hit real helpers, not mocks of helpers.
+- [no-go] **Refactor server.ts into multiple files** — explicit no-go per parent v0.1.6 §10.
+- Test for `permissionPattern` — covered by #10 shape, ships there.
+- Test for `chunkText`, `phonesMatch`, etc. — out of bootstrap scope; future PRs as helpers get touched.
+
+## §11 Rabbit holes
+
+### R-1: import.meta.main gate doesn't cover all side-effect cases
+- **Category**: bootstrap correctness
+- **Evidence (pre-bet)**: spike `spikes/import-meta-probe.ts` — imports server.ts from a test-style entry point and asserts: no `acquireLock` call, no `Bun.serve` call, no `mkdirSync` call, no `requireEnv` exit. Status: pending; will be the first thing the build does.
+- **Mitigation**: if individual side-effect blocks need their own gates, wrap each. Worst case: extract everything into a `bootstrap()` function (see §9 circuit breaker).
+
+### R-2: CI runtime under bun test
+- **Category**: ops
+- **Evidence**: bun test is fast (under 1s for the bootstrap suite). CI runtime should rise by < 5s. Probed on local Bun 1.3.13.
+- **Layer**: timing observation only
+
+### R-3: assertSendable/assertSendablePhone tests trigger real fs/state reads
+- **Category**: test isolation
+- **Evidence**: `assertSendable(f)` calls `realpathSync(f)` — needs a real fixture path. Tests should:
+  1. Use `Bun.tmpdir()` or `os.tmpdir()` for fixture paths (real but disposable).
+  2. Set `WHATSAPP_STATE_DIR` to a temp dir before importing server.ts.
+  3. Use `beforeAll` to mkdir the temp state dir; `afterAll` to clean.
+- **Mitigation**: pattern documented in `tests/assert-sendable.test.ts` template.
+
+### Anti-pattern lens (TPG)
+- "All tests pass" with no integration proof — addresses this. Bootstrap = unit. Integration tests come later (own MF).
+- "Heavy mocks with no real dependency validation" — avoid. Tests use real helpers, real filesystem (in tmp), real regex.
+
+## §12 S-DROP-G
+
+- **Security**: addressed — testing the security helpers is the whole point.
+- **Data**: N/A — no schema; tests use isolated tmp dirs.
+- **Resilience / Rollback**: revert single PR.
+- **Observability**: CI test step output is the metric.
+- **Platform**: no infra; CI runner already provisioned.
+- **Governance**: owner = Reinaldo. Kill-the-bet view: keep shipping fixture-script PRs forever — costly long-term but possible.
+
+## §13 Cutover
+
+**A (narrow fits)**. Single PR introduces tests + CI step + minimal server.ts changes; v0.1.6 spike removal is bundled but is a strict superset of work, no compat path.
+
+## §14 Pair shaping
+
+Async — Reinaldo PR review.
+
+## §15 Breadboard
+
+```
+Repo layout (post-MF):
+.
+├── server.ts              ← export helpers + import.meta.main gate at bottom
+├── tests/
+│   ├── sanitize.test.ts
+│   ├── safe-media-path.test.ts
+│   ├── assert-sendable.test.ts
+│   └── render-permission-body.test.ts
+├── package.json           ← + scripts.test
+├── .github/workflows/ci.yml ← + bun test step
+└── docs/shaping/v0.1.6-security-hotfix/pr4/spikes/  ← deleted post-merge
+
+CI flow:
+  checkout → setup-bun → bun install --frozen-lockfile → bunx tsc --noEmit → bun test
+```
+
+## §16 Build scopes
+
+### V1 — bootstrap + sanitizer + safe-media-path
+- `package.json` script
+- `.github/workflows/ci.yml` step
+- `tests/sanitize.test.ts` (port v0.1.6 + v0.2.0 cases)
+- `tests/safe-media-path.test.ts` (port v0.1.6 cases)
+- `server.ts` minimal: add `export` to `sanitizeSecrets`, `sanitizeDisplayName`, `safeMediaPath`; wrap side-effects in `import.meta.main`
+- README "Development" update
+- Delete `docs/shaping/v0.1.6-security-hotfix/pr4/spikes/sanitize-fixture.ts`
+- **change_type**: `other` (infra)
+- **required_test_layers**: `[static, unit]`
+- **evidence_plan**: tests pass locally + in CI; `git diff` confirms server.ts side-effects only run when invoked directly
+- **deferred_layers**: integration → out of scope (separate MF)
+- **V1**: yes
+
+### V2 — assertSendable + renderPermissionBody (cuttable)
+- `tests/assert-sendable.test.ts` — needs the helpers exported (already in V1) + temp-dir fixtures
+- `tests/render-permission-body.test.ts` — needs `renderPermissionBody` extracted from the inline body construction at server.ts:1058 area (~20 LOC refactor)
+- Delete `docs/shaping/v0.1.6-security-hotfix/pr4/spikes/render-body-fixture.ts`
+- **change_type**: `new-rule` (extraction) + `other` (tests)
+- **required_test_layers**: `[static, unit]`
+- **evidence_plan**: extracted function passes the 21 cases verbatim
+- **V1**: NO — cuttable per §9 circuit breaker
+
+If V2 doesn't fit, ledger a follow-up titled "migrate render-body + assert-sendable spikes to bun:test" under #25.
+
+## §17 Gate verification
+
+- SSOT: pass — N/A (single-file).
+- Single-path: pass — additive infra; no compat shim. The `import.meta.main` gate is not a feature flag — it's the canonical Bun idiom for "is this the entrypoint."
+- Type-safety: pass — exports are typed.
+- S-DROP-G: addressed.
+- Monorepo scan: every consumer (zero, since helpers are module-internal today) mapped.
+- Cutover: A.
+- Evidence-backed: R-1, R-2, R-3 all addressed pre-bet.
+- Test matrix: yes.
+
+All gates pass.
+
+## §18 Bet
+
+- **Decision**: pending — awaiting Reinaldo go-ahead.
+- **Reason**: shape is locked at A; only open call is "ship today as part of v0.2.0 cycle, or sequence after Cluster A?"
+- **Recommendation**: ship #28 BEFORE Cluster A (#7+#8+#12) so Cluster A can ship `tests/webhook-schema.test.ts` instead of another spike script. Cluster A would then BE the "first new test in the harness," validating the bootstrap.
+- **Approver**: Reinaldo
+- **Timestamp**: 2026-04-30 (shape produced)
+
+### Context payload
+- Blast radius: 1 file (server.ts, minimal changes) + 4 new test files + 2 config files
+- Risk class: **low** (additive infra, no behavior change)
+- Cutover: A
+- Appetite: 1 day; circuit breaker = drop V2 (assertSendable + render-body tests) if extraction is bigger than expected
+- Pair shaping: async

--- a/docs/shaping/v0.2.0-webhook-hardening/evidence.md
+++ b/docs/shaping/v0.2.0-webhook-hardening/evidence.md
@@ -1,0 +1,40 @@
+# Evidence — Cluster A (#7 + #8 + #12)
+
+## R-1: Streaming body-cap on Bun
+- Layer: unit fixture
+- Evidence type: spike `spikes/body-cap-probe.ts`
+- Status: complete (designed)
+- Notes: drains `req.body` (ReadableStream) chunk-by-chunk with running counter. Aborts via `controller.error()` when limit exceeded. Bun returns the in-flight promise as rejected, which the handler catches and returns 413.
+
+## R-2: Zod schema vs Meta payload variants
+- Layer: contract / unit fixture
+- Evidence type: spike `spikes/webhook-schema-probe.ts`
+- Status: complete (designed)
+- Notes: schema covers the subset `processWebhookPayload` actually reads. `passthrough()` on `z.object` lets Meta add fields without breaking. Real payload sample (PR1 manual probe captured `+5561985598585` voice note + document) parses cleanly.
+
+## R-3: Per-entry filtering regression risk
+- Layer: unit fixture (logical proof)
+- Evidence type: code reading + behavior delta analysis
+- Status: complete
+- Notes: current behavior at `processWebhookPayload` (server.ts:1238) reads `entry[0]`'s `phone_number_id` and rejects whole webhook on mismatch. New behavior is *strictly safer*. Concrete cases:
+
+| current state of webhook | old behavior | new behavior | change |
+|---|---|---|---|
+| 1 entry, OURS | process | process | none |
+| 1 entry, NOT OURS | reject all | reject all | none |
+| 2 entries, both OURS | process both | process both | none |
+| 2 entries, OURS + NOT OURS | process both (bug — OURS check only on `entry[0]`) | process OURS, log+skip NOT OURS | **bug fixed** |
+| 2 entries, NOT OURS + OURS | reject all (bug — `entry[0]` check rejects) | log+skip first, process OURS | **bug fixed** |
+
+## R-4: 413 status code path
+- Layer: observability
+- Evidence type: doc references (cloudflared, ngrok pass-through behavior)
+- Status: complete
+- Notes: log every 413 path so we can correlate if Meta's webhook stats show new "delivery failed" entries. If cloudflared collapses 413 to 502 for some reason, we'll see it in the plugin log first.
+
+## TPG anti-pattern lens
+- "Live dependency without synthetic check" — applies (Meta webhooks). Mitigated by zod schema + manual probe.
+- "All tests pass" with no integration proof — applies (no bun:test). Per-PR fixture script.
+
+## Follow-ups to file post-build
+- If zod schema turns out to need `passthrough` removed (some Meta variant has fields that look like ours but mean something else), follow-up under #25 v0.2.x.

--- a/docs/shaping/v0.2.0-webhook-hardening/shaping.md
+++ b/docs/shaping/v0.2.0-webhook-hardening/shaping.md
@@ -1,0 +1,309 @@
+# Shaping — Cluster A: Webhook hardening (#7 + #8 + #12)
+
+Bundle three issues that all touch the same ~50 lines of `Bun.serve` boot + webhook handler at `server.ts:1639-1687`. Single MF, hard cutover.
+
+## §0 Status TOC
+
+| # | Section | Status | Notes |
+|---|---|---|---|
+| 1 | Micro feature | ✓ | webhook server hardening — body cap + hostname pin + zod validation |
+| 2 | Problem | ✓ | 3 vectors at the webhook entry point: DoS, exposure, untyped payload |
+| 3 | Outcome | ✓ | each issue closed with citable fix; observable at HTTP surface |
+| 4 | Why now | ✓ | last security-flavored cluster of v0.2.0 hardening; surface is small + hot |
+| 5 | Monorepo scan | ✓ | single file (`server.ts`); 1 inbound webhook surface; 0 external consumers |
+| 6 | Requirements | ✓ | per-issue acceptance below |
+| 7 | Candidate shapes | ✓ | 1 chosen — bundle with shared diff |
+| 8 | Selected shape | ✓ | one PR, ~50 LOC, atomic |
+| 9 | Appetite | ✓ | 1 day inside cycle |
+| 10 | In/Out scope | ✓ | webhook entry only; payload-validation-everywhere out |
+| 11 | Rabbit holes | ✓ | 4 risks, 3 with pre-bet evidence |
+| 12 | S-DROP-G | ✓ | all dimensions decided |
+| 13 | Cutover | ✓ | A (narrow fits) |
+| 14 | Pair shaping | ✓ | async — Reinaldo PR review |
+| 15 | Breadboard | ✓ | inbound HTTP → cap → sig verify → zod parse → enqueue |
+| 16 | Build scopes | ✓ | single scope, 3 sub-changes |
+| 17 | Gate verification | ✓ | passes |
+| 18 | Bet | ○ | awaiting Reinaldo go-ahead |
+
+**Siblings:** evidence.md · spikes/
+
+---
+
+## §1 Micro feature
+
+Harden the webhook server boot in `server.ts:1639-1687`:
+
+1. Add a JSON body size cap to reject `> 1 MB` payloads early (issue **#7**).
+2. Pin `Bun.serve` hostname to `127.0.0.1` explicitly (issue **#8**).
+3. Validate the webhook payload with a zod schema and check `phone_number_id` per `entry[]` element (issue **#12**) — currently only checked on the first entry.
+
+## §2 Problem
+
+`server.ts:1639-1679` is the entry point for every Meta webhook. Three weaknesses:
+
+### #7 — no body size cap (server.ts:1664)
+
+```ts
+if (req.method === 'POST' && url.pathname === '/webhook') {
+  const rawBody = await req.text()   // ← unbounded
+  const sig = req.headers.get('x-hub-signature-256')
+  if (!verifyHubSignature(rawBody, sig)) { ... }
+```
+
+A malicious caller pointing at the public tunnel can stream gigabytes into `req.text()`. The Bun process buffers the whole body in memory before HMAC verification runs, so the rejection at signature-mismatch time happens *after* allocation. Tunnel ingress + memory pressure → OOM kill.
+
+The HMAC check after the fact is irrelevant for DoS — the cost is paid before the check.
+
+### #8 — Bun.serve binds 0.0.0.0 by default (server.ts:1639-1687)
+
+```ts
+const httpServer = Bun.serve({
+  port: WEBHOOK_PORT,
+  async fetch(req) { ... },
+})
+```
+
+No `hostname` field. Bun's default is `0.0.0.0` (all interfaces). On a multi-tenant host (or one with a routable IPv6), the webhook listener is reachable beyond the tunnel. README claims the plugin binds to `localhost`; it does not. The HMAC check on every POST contains exposure but the listener itself is reachable.
+
+### #12 — webhook payload typed via `as any` (server.ts:1671 + processWebhookPayload)
+
+```ts
+const payload = JSON.parse(rawBody)
+void processWebhookPayload(payload)
+```
+
+`payload: unknown` flows through `processWebhookPayload`, which casts liberally. `parseWebhookPayload(payload)` (downstream) does manual property access without validation. Two concrete consequences:
+
+- **Inconsistent `phone_number_id` check** — `processWebhookPayload` validates the metadata `phone_number_id` only for `entry[0]`, ignoring entries 1+. Meta does send batched webhooks with multiple `entry[]` items in pricing-tier scenarios.
+- **Type erosion** — every downstream `(payload as any).entry?.[0]?.changes?.[0]?.value?.metadata?.phone_number_id` is a chain of `unknown` access. Bugs from missing fields surface as silent drops, not loud failures.
+
+## §3 Outcome
+
+Observable success metrics:
+
+1. **Body cap probe**: `curl -X POST -d "$(head -c 2000000 /dev/urandom | base64)" $WEBHOOK_URL` returns `413 payload too large` within 100ms; plugin memory does not climb.
+2. **Hostname probe**: `lsof -i :3789` after plugin start shows `127.0.0.1:3789` only — no IPv6 or 0.0.0.0 binding.
+3. **Schema rejection probe**: a valid HMAC signed POST with malformed JSON (e.g., `{"entry":[{"changes":[]}]}` missing `value`) returns `200` (Meta retry contract preserved) but plugin logs `webhook payload schema rejected: <zod issue>` and does not invoke `processWebhookPayload`.
+4. **Per-entry phone_number_id**: a valid POST with two entries (`entry[0]` for our number, `entry[1]` for another WABA) processes only the matching entry; the other is logged-and-skipped, not silently merged.
+5. Issues #7, #8, #12 closed via PR-merge.
+
+## §4 Why now
+
+Last "security-flavored" cluster of the v0.2.0 cycle. The webhook surface is *the* entry point — every threat model that touches inbound starts here. Body-cap + hostname-pin in particular are 5-line changes that should have been in v0.1.6 if the appetite had allowed (per parent v0.1.6 §10 Out-of-scope). #12 is bigger but groups naturally because it touches the same handler block.
+
+## §5 Monorepo scan
+
+Single file (`server.ts`). Touched surfaces:
+
+### Surface 1: `Bun.serve` boot (server.ts:1639-1687)
+Consumers: 0 (the server is the producer, not a consumer of anything observable).
+External consumer: Meta Graph API (sends webhooks). No contract change visible to Meta (we still return 200 on accepted POSTs).
+
+### Surface 2: webhook payload parser (`processWebhookPayload`, `parseWebhookPayload`)
+Locations: `processWebhookPayload` at server.ts:1238+, `parseWebhookPayload` (downstream).
+Consumers (call graph from L1674 `void processWebhookPayload(payload)`):
+- inbound message handling at `parseWebhookPayload`
+- `lastInboundByChat.set` at L1576 (post-PR4 numbering)
+- `activeTask` set at L1567+ (#6 expiresAt now too)
+- HMAC reply handling for permission relay (L1336)
+- All inbound database writes (`stmtInsertMsg`)
+
+Single producer (this webhook handler), single in-process consumer chain. No cross-service.
+
+### Surface 3: env var addition
+New: `WHATSAPP_WEBHOOK_HOSTNAME` (optional, default `127.0.0.1`) — escape hatch for operators who run the plugin in unusual network setups (e.g., Docker bridge requiring `0.0.0.0`).
+New: `WHATSAPP_WEBHOOK_BODY_LIMIT_BYTES` (optional, default `1048576` = 1 MB).
+
+### Constraints
+- WhatsApp Cloud API webhook payloads in practice are < 50 KB (single message + metadata). 1 MB cap leaves 20× headroom for batched deliveries.
+- Meta's retry contract: HTTP 200 within 20s = "delivered"; non-200 or timeout = retried up to 24h. Schema-rejected payloads should still return 200 (logged and dropped) rather than 4xx, otherwise Meta retry-storms a malformed entry forever.
+- HMAC check at L1666 must run BEFORE schema validation — skipping it would let unsigned junk reach the parser.
+
+## §6 Requirements
+
+### #7 — body cap
+
+- Add `WHATSAPP_WEBHOOK_BODY_LIMIT_BYTES` env (default `1_048_576` = 1 MB).
+- Read `Content-Length` header; if present and exceeds cap, return `413` immediately.
+- For `Content-Length` absent or unreliable, read body via streaming and abort if cumulative bytes exceed cap. Bun supports `req.body` as a `ReadableStream` — drain with size guard.
+- Cap rejection happens **before** HMAC verification (the body isn't trustworthy enough to spend signature-compute on).
+
+### #8 — hostname pin
+
+- Add `WHATSAPP_WEBHOOK_HOSTNAME` env (default `127.0.0.1`).
+- Pass `hostname` in the `Bun.serve` config: `Bun.serve({ port, hostname: WEBHOOK_HOSTNAME, fetch })`.
+- README "Quick Setup" step 4 already says "expose localhost" — update if needed for accuracy (it implies localhost binding which now becomes truth).
+
+### #12 — zod payload validation + per-entry phone_number_id
+
+- Define a zod schema that mirrors the Meta webhook payload shape (subset we use): `entry[]` with `changes[]`, each change with `value.metadata.phone_number_id` + optional `value.messages[]` + optional `value.contacts[]`.
+- After HMAC verify and JSON.parse, run `WebhookPayload.safeParse(payload)`. On failure: `log` the zod issue + return 200 (Meta contract). On success: continue.
+- Inside `processWebhookPayload`, replace the manual `as any` access with the typed result. Iterate **per entry**, validating `phone_number_id` for each — drop entries that don't match `PHONE_NUMBER_ID`, process those that do. Log `webhook ignored (phone_number_id mismatch): <id>` per skipped entry.
+
+## §7 Candidate shapes
+
+### Shape A: Single PR, single bundle (recommended)
+- All three changes in one PR (~50 LOC net).
+- One review round, atomic ship.
+- Pros: same surface, same review context, no cross-PR coordination.
+- Cons: one fix's regression blocks all three.
+
+### Shape B: 3 separate PRs (#7, #8, #12)
+- Open three small PRs.
+- Pros: each can ship independently if one needs more iteration.
+- Cons: 3 review cycles, 3× CI runs, plus the schema validation in #12 makes the type story across the file inconsistent until all three land. Adds ceremony for a 50-LOC change.
+
+**Selected: Shape A.**
+
+## §8 Selected shape
+
+One PR, branch `fix/v0.2.0-webhook-hardening`. Three sub-changes ordered:
+
+1. **Body cap** (env + cap check + 413 path) — closes #7
+2. **Hostname pin** (env + Bun.serve hostname field) — closes #8
+3. **Zod schema + per-entry validation** — closes #12
+
+Total ~50 LOC + maybe 25 LOC for the schema. PR body groups changes by issue with line-cited evidence.
+
+## §9 Appetite
+
+- **Time-box**: 1 day.
+- **Circuit breaker**: if the streaming body-cap path proves harder than expected (Bun stream API quirks), drop the streaming guard and rely on `Content-Length` header only — log a warning if header is absent and fall through to the existing unguarded path. Ledger a follow-up to add streaming guard when bun:test harness is in place to prove it.
+- **Why time-box is enough**: surface is ~50 LOC in one block; zod schema is the only design call; existing code does manual access we can typecheck against.
+- **Must-fit**: #7 (body cap) — even header-only is enough for v0.2.0; #8 (1-line); #12 (zod schema + per-entry).
+- **First cut**: streaming body-cap (header-only stays).
+
+## §10 In-scope / Out-of-scope
+
+### In-scope
+- Body size cap on `/webhook` POST
+- `Bun.serve` hostname pin
+- Zod schema for webhook payload
+- Per-entry `phone_number_id` validation
+- README "Quick Setup" tweak if the hostname change requires it (probably not — it already says "localhost")
+- Two new env vars + their docs in README
+
+### Out-of-scope
+- [no-go] **Validation everywhere** — only the inbound webhook payload gets the schema. Outbound Graph API responses, MCP tool args, etc. are separate MFs.
+- [no-go] **Restructure error handling** — non-zero return codes for various failure modes is a separate UX/observability MF.
+- [no-go] **Add new tools** — hardening only.
+- [no-go] **Change HMAC compute** — `verifyHubSignature` stays as-is (constant-time compare is already correct).
+- TLS termination at the plugin (Meta requires HTTPS but operators use tunnels) — out of scope; tunnel handles TLS.
+
+## §11 Rabbit holes
+
+### R-1: streaming body-cap on Bun has quirks
+- **Category**: external integration (Bun's request body API)
+- **Evidence (pre-bet)**: spike at `spikes/body-cap-probe.ts` proves `req.body` (ReadableStream) can be drained chunk-by-chunk with a running byte counter, aborting via `controller.error(...)` when limit exceeded. **Status: complete (designed)**.
+- **Mitigation**: if the stream guard misbehaves, fall back to `Content-Length` header check only. Header-only is ~80% of the threat surface anyway (most malicious POSTs do send a length header).
+
+### R-2: zod schema misses a Meta payload variant
+- **Category**: contract drift
+- **Evidence (pre-bet)**: schema based on actual `processWebhookPayload` access paths + Meta's documented webhook reference. Real-world payload sample captured during PR1 manual probe (Reinaldo's number, voice note + document) matches the schema.
+- **Mitigation**: schema marks unknown fields as `passthrough()` (zod default for `z.object`) so adding fields Meta later sends doesn't break us. If a known-required field is missing, we log and 200 (Meta retry behavior unchanged from current).
+- **Layer**: contract / unit fixture
+
+### R-3: per-entry filtering changes behavior for batched webhooks
+- **Category**: regression risk
+- **Per-consumer impact**: `parseWebhookPayload` currently iterates entries already; adding the per-entry `phone_number_id` gate means entries from other WABAs (which we shouldn't see in practice — Meta routes by configured WABA — but theoretically possible) get dropped instead of silently processed alongside ours.
+- **Evidence**: the current code at `processWebhookPayload` (server.ts:1238) reads `inboundPhoneId = (payload as any)?.entry?.[0]?.changes?.[0]?.value?.metadata?.phone_number_id` and rejects the WHOLE webhook if `entry[0]`'s phone_number_id doesn't match. The new behavior is *strictly safer* — we now process matching entries and skip non-matching ones instead of accepting them via off-by-one. If there's any production payload that today processes correctly because `entry[0]` is the one we want and `entry[1]` happens to also be ours, the new behavior still processes both. The only behavior change is when `entry[0]` is OURS and `entry[1]` is NOT — old code processed both (bug), new code processes only the first.
+- **Layer**: unit fixture
+
+### R-4: 413 status code surprises tunnel/proxy stacks
+- **Category**: ops
+- **Evidence**: `cloudflared tunnel` documented to forward arbitrary status codes through. `ngrok` ditto. No known proxy that re-codes 413 to something else. Mitigation: log every 413 path so we can correlate if Meta complains.
+- **Layer**: observability
+
+### Anti-pattern lens (TPG)
+- ✅ "Live dependency without synthetic check" — applies to Meta webhooks. Mitigated by zod schema + the existing HMAC check + manual probe at PR review.
+- ✅ "All tests pass" with no integration proof — applies (still no `bun:test` harness; tracked under #28). Per-PR fixture script in PR body.
+- ❌ Migration testing — N/A, no schema change.
+- ❌ Retry/idempotency — N/A, Meta retries are observed not changed.
+
+## §12 S-DROP-G
+
+- **Security**: addressed — three explicit hardening changes. AuthZ unchanged (HMAC stays). New env vars rotation: not applicable (config, not credentials).
+- **Data**: N/A — no schema, no migration.
+- **Resilience / Rollback**: addressed. Single revert. **Kill switch**: env vars allow operator to disable the new behavior partially: set `WHATSAPP_WEBHOOK_BODY_LIMIT_BYTES=0` to disable cap, set `WHATSAPP_WEBHOOK_HOSTNAME=0.0.0.0` to revert to all-interface bind. These are escape hatches, not compat path — single-path gate satisfied.
+- **Observability**: addressed. Three new log lines: `webhook rejected (size > N bytes)`, `webhook bound to <hostname>:<port>` (already in startup log), `webhook payload schema rejected: <zod issue>` and `webhook ignored (phone_number_id mismatch): <id>`. All structured `log()` calls.
+- **Platform**: addressed — no infra change. Two env vars added with safe defaults; existing operators see no behavior change unless they set the override.
+- **Governance**: owner = Reinaldo. Kill-the-bet view: not doing it leaves the public tunnel reachable by 0.0.0.0 + DoS-able + untyped — acceptable for v0.1.x but not for marketplace v0.2.0.
+
+## §13 Cutover decision
+
+**A (narrow fits)**. Triggers: zero. All three sub-changes are atomic, single-file, no compat shim. Hostname change has the env-var escape hatch but that's an operational kill switch, not a compat path.
+
+## §14 Pair shaping
+
+Async — Reinaldo PR review. No live session needed; design space is constrained by Bun's API surface + Meta's documented payload shape.
+
+## §15 Breadboard
+
+```
+Meta → POST /webhook
+  │
+  ├─ [#7 NEW] Content-Length check  →  if > limit: 413
+  │
+  ├─ [#7 NEW] streaming drain with size guard  →  if exceeded: 413
+  │
+  ├─ HMAC verify (server.ts:1666 — unchanged)
+  │
+  ├─ [#12 NEW] WebhookPayload.safeParse(JSON.parse(body))
+  │     │
+  │     ├─ on fail: log + 200 (Meta retry preserved)
+  │     │
+  │     └─ on success: validated payload
+  │
+  ├─ [#12 NEW] for each entry in payload.entry:
+  │     │
+  │     ├─ if entry.changes[0].value.metadata.phone_number_id !== PHONE_NUMBER_ID:
+  │     │     log + skip
+  │     │
+  │     └─ else: processWebhookPayload(entry)
+  │
+  └─ 200 OK
+
+Bun.serve hostname [#8 NEW] = WHATSAPP_WEBHOOK_HOSTNAME (default 127.0.0.1)
+```
+
+## §16 Build scopes
+
+Single scope, three sub-changes:
+
+### Scope: webhook-hardening
+
+- **change_type**: `new-rule` (cap + zod) + `new-rule` (hostname pin) — bundled
+- **required_test_layers**: `[static, unit (fixture), manual probe at review]`
+- **evidence_plan**:
+  - static: typecheck via existing CI
+  - unit fixture: spike that exercises the cap logic + the zod schema against representative payloads + the per-entry filter
+  - manual probe at review: Reinaldo confirms `lsof -i :3789` shows 127.0.0.1; sends an oversized payload via curl and observes 413; sends a real WhatsApp message and confirms the typed flow still works
+- **deferred_layers**: integration → tracked under #28 (bun:test harness)
+- **V1**: yes (entire scope)
+
+## §17 Gate verification (pre-bet)
+
+- SSOT: pass — N/A (single-file repo).
+- Single path: pass — env-var kill switches are operational, not compat. Cutover §13 = A.
+- Type safety: pass — zod schema replaces `as any` chains; `z.infer` provides typed downstream access.
+- S-DROP-G: addressed.
+- Monorepo scan: every consumer mapped.
+- Cutover: A.
+- Evidence-backed: R-1, R-2, R-3 have spike or design evidence; R-4 is observability mitigation.
+- Test matrix: scope has change_type + required_test_layers + evidence_plan.
+
+All gates pass.
+
+## §18 Bet
+
+- **Decision**: pending — awaiting Reinaldo go-ahead on shape.
+- **Approver**: Reinaldo via PR review on this shape commit.
+- **Timestamp**: 2026-04-30 (shape produced)
+- **shaping_commit_sha**: filled at commit.
+
+### Context payload
+- Blast radius: 1 file, ~75 LOC, 0 cross-service consumers
+- Risk class: **medium** (security surface change, but well-bounded; not high since no SSOT change, no cross-tenant, no data migration)
+- Cutover: A
+- Appetite: 1 day; circuit breaker = drop streaming guard, header-only fallback
+- Pair shaping: async


### PR DESCRIPTION
## Summary

Three shape docs for the v0.2.0 cycle, picking up from the 5 Cluster B PRs you merged earlier:

1. **Cluster A — webhook hardening** (#7 + #8 + #12) at \`docs/shaping/v0.2.0-webhook-hardening/\`
2. **#10 pattern granularity** at \`docs/shaping/10-pattern-granularity/\` — **has open design call**
3. **#28 bun:test harness** at \`docs/shaping/28-bun-test-harness/\`

This is a tracking PR for the shape docs themselves. No code change. Each shape ships as its own PR after you sign off here.

## Reading guide

Each shape doc has §0 Status TOC at the top — skim that first to see which sections need your eyes.

### Cluster A (#7+#8+#12) — ready to bet
- Single MF bundling all three issues since they touch the same ~50 LOC at \`server.ts:1639-1687\`.
- §7 selected: Shape A (single PR, atomic).
- §18 awaits your go-ahead.
- Risk class: medium. 1-day appetite. Cutover A.

### #10 pattern granularity — needs your pick on §7
Three candidate shapes:

| Shape | Pattern format | LOC | UX trade-off |
|---|---|---|---|
| **A — first 2 tokens** *(recommended)* | \`Bash:git status\` vs \`Bash:git push\` | ~5 | Always on \`git status\` re-prompts on \`git push\`. Mental model unchanged. |
| **B — safe verb classification** | \`Bash:git:safe\` vs \`Bash:git:unsafe\` via per-verb safe-list | ~30 | Always on \`git status\` auto-approves \`git diff/log/show\` but re-prompts on \`git push\`. Higher utility, higher maintenance. |
| **C — drop \"Always\" entirely** | N/A; remove the feature | ~−50 | Every permission re-prompts. Matches telegram + imessage canonical. Operator fatigue. |

Pick one in a comment here and I lock §8 + run \`/build\`.

### #28 bun:test harness — ready to bet
- Shape A locked: \`bun:test\` native + \`tests/\` sibling + \`import.meta.main\` gate to suppress server.ts side-effects during test imports.
- V1 (bootstrap + sanitizer + safe-media-path) is the must-fit; V2 (assert-sendable + render-body) is cuttable.
- §18 awaits your go-ahead.
- **Recommendation**: ship #28 BEFORE Cluster A, so Cluster A's zod schema tests live in the new harness instead of yet another spike script.

## Suggested sequence (open for your reorder)

1. Approve #28 → \`/build\` → CI green with \`bun test\` step
2. Approve Cluster A → \`/build\` (ships with proper tests via #28)
3. You pick #10 §7 shape → \`/build\`
4. Tag \`v0.2.0\` (similar metadata-bump PR to v0.1.6's #24)

## Files

\`\`\`
docs/shaping/v0.2.0-webhook-hardening/
  ├── shaping.md       (~280 lines)
  └── evidence.md      (~50 lines)

docs/shaping/10-pattern-granularity/
  ├── shaping.md       (~210 lines)
  └── (no evidence.md yet — waits for shape pick)

docs/shaping/28-bun-test-harness/
  ├── shaping.md       (~270 lines)
  └── evidence.md      (~70 lines)
\`\`\`

## Test plan
- [ ] Reinaldo reads §0 of each shape, deep-reads sections marked with open decisions
- [ ] Reinaldo picks #10 §7 (A/B/C) in a comment
- [ ] Reinaldo signs off on Cluster A and #28 §18
- [ ] PR closes once builds for all 3 ship

🤖 Generated with [Claude Code](https://claude.com/claude-code)